### PR TITLE
Update for readable stream spec changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,18 @@
   <head>
     <title>TCP and UDP Socket API</title>
     <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
-    <!-- 
+    <!--
       === NOTA BENE ===
       For the three scripts below, if your spec resides on dev.w3 you can check them
       out in the same tree and use relative links so that they'll work offline,
      -->
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove' 
-            async></script> 
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'
+            async></script>
     <script class='remove'>
       var respecConfig = {
           // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
           specStatus:           "ED",
-          
+
           // the specification's short name, as in http://www.w3.org/TR/short-name/
           shortName:            "raw-sockets",
 
@@ -29,7 +29,7 @@
           // the start date here:
           // copyrightStart: "2005"
 
-          // if there is a previously published draft, uncomment this and set its 
+          // if there is a previously published draft, uncomment this and set its
           // YYYY-MM-DD date
           // and its maturity status
           // previousPublishDate:  "1977-03-15",
@@ -47,12 +47,12 @@
 
           // editors, add as many as you like
           // only "name" is required
-          editors:  [             
+          editors:  [
               { name: "Claes Nilsson", url: "claes1.nilsson@sonymobile.com",
                 company: "Sony Mobile", companyURL: "http://www.sonymobile.com" },
           ],
 
-          // authors, add as many as you like. 
+          // authors, add as many as you like.
           // This is optional, uncomment if you have authors as well as editors.
           // only "name" is required. Same format as editors.
 
@@ -60,62 +60,62 @@
           //    { name: "Your Name", url: "http://example.org/",
           //      company: "Your Company", companyURL: "http://example.com/" },
           //],
-          
+
           // name of the WG
           wg:           "System Applications Working Group",
-          
+
           // URI of the public WG page
           wgURI:        "http://www.w3.org/2012/sysapps/",
-          
+
           // name (without the @w3c.org) of the public mailing to which comments are due
           wgPublicList: "public-sysapps",
-          
+
           // URI of the patent status for this WG, for Rec-track documents
           // !!!! IMPORTANT !!!!
-          // This is important for Rec-track documents, do not copy a patent 
-          // URI from a random document unless you know what you're doing. If in 
+          // This is important for Rec-track documents, do not copy a patent
+          // URI from a random document unless you know what you're doing. If in
           // doubt ask your friendly neighbourhood Team Contact.
           wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/58119/status",
-          
+
           localBiblio:  {
             // Reference to the Nagle algorithm
             "NAGLE": {
-              title:    "Nagle algorithm", 
+              title:    "Nagle algorithm",
               href:     "http://www.rfc-editor.org/rfc/rfc896.txt",
               authors:  [
                "John Nagle"
-              ],   
+              ],
               status:   "Request For Comments",
               publisher:  "IETF"
-            },   
-            
-            // Reference to the WHATWG Streams API specification          
+            },
+
+            // Reference to the WHATWG Streams API specification
             "STREAMS": {
-              "title": "Streams API",            
+              "title": "Streams API",
               "href": "https://streams.spec.whatwg.org/",
-              "authors": ["Domenic Denicola"],              
+              "authors": ["Domenic Denicola"],
               "status": "Living standard",
               "publisher": "WHATWG"
             },
-            
-            // Reference to the W3C Streams API specification          
+
+            // Reference to the W3C Streams API specification
             "W3C-STREAMS": {
-              "title": "W3C Streams API",            
+              "title": "W3C Streams API",
               "href": "https://dvcs.w3.org/hg/streams-api/raw-file/tip/Overview.htm",
-              "authors": ["Feras Moussa", "Takeshi Yoshino"],              
+              "authors": ["Feras Moussa", "Takeshi Yoshino"],
               "status": "ED",
               "publisher": "W3C"
-            },        
-            
-            // Reference to the ECMAScript, edition 6, specification        
+            },
+
+            // Reference to the ECMAScript, edition 6, specification
             "ES6": {
-              "title": "ECMA-262, 6th Edition / Draft January 20, 2014",            
-              "href": "http://people.mozilla.org/~jorendorff/es6-draft.html",        
+              "title": "ECMA-262, 6th Edition / Draft January 20, 2014",
+              "href": "http://people.mozilla.org/~jorendorff/es6-draft.html",
               "status": "Draft",
               "publisher": "Ecma International"
-            }                    
+            }
           },
-          
+
           otherLinks: [{
             key: "Repository",
             data: [{
@@ -129,11 +129,11 @@
                     href: "https://github.com/sysapps/raw-sockets/commits/gh-pages"
                 }
             ]
-          }]          
+          }]
       };
     </script>
   </head>
-  
+
 <!-----------------------------------------------------------------------------
 Style guide to contributors:
 ============================
@@ -148,72 +148,72 @@ Style guide to contributors:
 - when descriptions of attributes is short, use the <dd> elements even when
   the text also contains conformance statements (e.g. MUST, SHOULD, MAY).
   No use repeating the same information in a separate paragraph.
------------------------------------------------------------------------------->  
-  
+------------------------------------------------------------------------------>
+
   <body>
-  
-<!------------------------------ Abstract ------------------------------------>    
+
+<!------------------------------ Abstract ------------------------------------>
     <section id='abstract'>
       <p>
-        This API provides interfaces to raw UDP sockets, TCP Client sockets and 
-        TCP Server sockets. 
-      </p>            
+        This API provides interfaces to raw UDP sockets, TCP Client sockets and
+        TCP Server sockets.
+      </p>
     </section>
-    
-    
-<!----------------------------- Custom Status of this document section ------->    
+
+
+<!----------------------------- Custom Status of this document section ------->
     <section id='sotd'>
       <div class="note">
         <p>
           This specification is based the Streams API, [[!STREAMS]]. Note that the
           Streams API is work in progress and any changes made to Streams may
-          impact the TCP and UDP Socket API specification. However, it is the 
+          impact the TCP and UDP Socket API specification. However, it is the
           editor's ambition to continously update the TCP and UDP API specification
           to be aligned with the latest version the Streams API.
         </p>
-      </div>   
-      
+      </div>
+
       <div class="note">
         <p>
-          This is a note on error handling. 
+          This is a note on error handling.
         </p>
         <p>
-          When using promises rejection reasons should always be instances of 
-          the ECMAScript Error type such as DOMException or the built in 
-          ECMAScript error types. See 
+          When using promises rejection reasons should always be instances of
+          the ECMAScript Error type such as DOMException or the built in
+          ECMAScript error types. See
           <a href="http://www.w3.org/2001/tag/doc/promises-guide#errors">Promise rejection reasons</a>.
           In the TCP and UDP Socket API the error names defined in <a href="http://heycam.github.io/webidl/#idl-DOMException-error-names">
           WebIDL Exceptions</a> are used. If additional error names are needed an update to <a href="https://github.com/heycam/webidl/">
-          Github WebIDL</a> should be requested through a Pull Request. 
+          Github WebIDL</a> should be requested through a Pull Request.
         </p>
 
-      </div>    
-      
+      </div>
+
       <div class="note">
         <p>
-          This is a note on data types of TCP and UDP to send and receive. 
+          This is a note on data types of TCP and UDP to send and receive.
         </p>
         <p>
-          In the previous version of this API the send() method accepted the 
-          following data types for the data to send: DOMString,Blob, ArrayBuffer 
-          or ArrayBufferView. This was aligned with the send() method for 
+          In the previous version of this API the send() method accepted the
+          following data types for the data to send: DOMString,Blob, ArrayBuffer
+          or ArrayBufferView. This was aligned with the send() method for
           Web Sockets. In this Streams API based version only ArrayBuffer is
-          accepted as type for data to send. The reason is that encoding issues 
-          in a Streams based API should instead be handled by a transform 
+          accepted as type for data to send. The reason is that encoding issues
+          in a Streams based API should instead be handled by a transform
           stream.
-        </p>        
-        
-      </div>   
+        </p>
+
+      </div>
     </section>
-    
-    
+
+
 <!----------------------------- Introduction --------------------------------->
     <section class="informative">
       <h2>Introduction</h2>
       <p>
-        Use this API to send and receive data over the network using TCP or UDP. 
+        Use this API to send and receive data over the network using TCP or UDP.
       </p>
-      
+
       <p>
         Examples of use cases for this API are:
       </p>
@@ -225,44 +225,44 @@ Style guide to contributors:
         <li> Game servers
         <li> Peer-to-peer applications
         <li> Local network multicast service discovery, e.g. UPnP/SSDP and mDNS
-      </ul>      
-      
+      </ul>
+
     </section>
-    
+
 <!---------------------------- Conformance ----------------------------------->
     <section id="conformance">
-      <p>This specification defines conformance criteria that apply to a single 
-         product: the <dfn>user agent</dfn> that implements the interfaces that 
+      <p>This specification defines conformance criteria that apply to a single
+         product: the <dfn>user agent</dfn> that implements the interfaces that
          it contains.
       </p>
-      
-      <p>Implementations that use ECMAScript to implement the APIs defined in this 
-         specification MUST implement them in a manner consistent with the ECMAScript 
+
+      <p>Implementations that use ECMAScript to implement the APIs defined in this
+         specification MUST implement them in a manner consistent with the ECMAScript
          Bindings defined in the Web IDL specification [[!WEBIDL]], as this
          specification uses that specification and terminology.
-      </p>          
-      
+      </p>
+
     </section>
-    
+
 <!----------------------------- Terminology ---------------------------------->
     <section>
       <h2>Terminology</h2>
-      
+
       <p>
         The term <dfn>webapp</dfn> refers to a Web application, i.e. an
         application implemented using Web technologies, and executing within
-        the context of a Web <a>user agent</a>, e.g. a Web browser or other 
+        the context of a Web <a>user agent</a>, e.g. a Web browser or other
         Web runtime environment.
       </p>
-      
+
       <p>
-        The <dfn id="promise"><code><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></code></dfn> 
-        interface provides asynchronous access to the result of an operation 
+        The <dfn id="promise"><code><a href="http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a></code></dfn>
+        interface provides asynchronous access to the result of an operation
         that is ongoing, has yet to start, or has completed, as defined in
         [[!ES6]].
 
       </p>
-      
+
     </section>
 
 <!------------------------ Security and privacy ------------------------------>
@@ -270,70 +270,70 @@ Style guide to contributors:
       <h2>Security and privacy considerations</h2>
       <p>
         This is a security and privacy sensitive API and a <a>webapp</a> must
-        have permission to use the API. The manner in which permission is given 
-        or not varies depending on the type of web runtime environment in which 
+        have permission to use the API. The manner in which permission is given
+        or not varies depending on the type of web runtime environment in which
         this API is implemented and could be based on:
         <ul>
           <li>Consent through user interaction.</li>
           <li>Previously granted or denied permission explicitly for this webapp.
-          <li>Explicit trust for the requesting <a>webapp</a> based on the 
+          <li>Explicit trust for the requesting <a>webapp</a> based on the
               security system of the web runtime this API is implemented in.</li>
-          <li>A combination of above.</li>       
+          <li>A combination of above.</li>
         </ul>
       </p>
-      
+
       <p>
         The <a>UDPPermission</a>, <a>TCPPermission</a> and <a>TCPServerPermission</a>
-        interfaces provides a method <code>hasPermission</code> that retrieves 
-        the permission state for the requesting <a>webapp</a> and a method 
+        interfaces provides a method <code>hasPermission</code> that retrieves
+        the permission state for the requesting <a>webapp</a> and a method
         <code>requestPermission</code> that requests permission for the <a>webapp</a>
-        to use the socket interface. If a <a>webapp</a> calls the contructor of a 
+        to use the socket interface. If a <a>webapp</a> calls the contructor of a
         socket interface for which it has not permission to access the
         <a>user agent</a> MUST immediately throw DOMException
-        <code>"SecurityError"</code>.       
+        <code>"SecurityError"</code>.
       </p>
-            
+
       <p class="note">
-        The idea behind the <a>UDPPermission</a>, <a>TCPPermission</a> and 
-        <a>TCPServerPermission</a> interfaces is to isolate the permission 
-        system from the socket interfaces specifications. The manner in which 
-        permission to use this API differs depending on the type of web runtime 
-        it is implemented in. For example, a web runtime for secure installed 
-        web applications may be able to open up this API so that no explicit 
-        user content is needed, while an implementation in a web browser may 
+        The idea behind the <a>UDPPermission</a>, <a>TCPPermission</a> and
+        <a>TCPServerPermission</a> interfaces is to isolate the permission
+        system from the socket interfaces specifications. The manner in which
+        permission to use this API differs depending on the type of web runtime
+        it is implemented in. For example, a web runtime for secure installed
+        web applications may be able to open up this API so that no explicit
+        user content is needed, while an implementation in a web browser may
         use a combination of web security mechanisms, such as secure transport
         (https:), content security policies (CSP) and a signed manifest,
-        and user consent to open up the API.</br></br>    
+        and user consent to open up the API.</br></br>
         The <a href="https://w3c.github.io/permissions/">Permissions API</a>,
         which currently is an unofficial draft, is an API that allows a web
-        application to be aware of the status of a given permission, to know 
+        application to be aware of the status of a given permission, to know
         whether it is granted, denied or if the user will be asked whether the
-        permission should be granted or not. If this API gets consensus and 
+        permission should be granted or not. If this API gets consensus and
         becomes a W3C standard, and also is extended to support permission
-        requests, it may be possible to replace the <code>hasPermission</code> 
+        requests, it may be possible to replace the <code>hasPermission</code>
         and <code>requestPermission</code> methods in this specification with
-        a reference to the Permission API. </br></br>      
+        a reference to the Permission API. </br></br>
         W3C has activities on security for web applications, see
         <a href = "http://www.w3.org/2011/webappsec/">Web Application Security Working Group</a>
-        and on trust and permissions, see 
+        and on trust and permissions, see
         <a href = "http://www.w3.org/2014/07/permissions/minutes.html">
         Workshop on trust and permissions for Web applications 3–4 September
         2014, Paris, France</a> and <a href = "http://www.w3.org/community/trustperms/">
-        Trust & Permissions Community Group</a>.  
+        Trust & Permissions Community Group</a>.
         </br></br>
-        The CSP directive <a href="https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-1.0-specification.html#connect-src">connect-src</a> 
-        is used to restrict the allowed connection targets for XHR, Web Sockets 
+        The CSP directive <a href="https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-1.0-specification.html#connect-src">connect-src</a>
+        is used to restrict the allowed connection targets for XHR, Web Sockets
         and Server-Sent Events. It should be considered if <a href="https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-1.0-specification.html#connect-src">connect-src</a>
         should be extended to support allowed remote peers for raw TCP and UDP
         sockets as well. However, currently the allowed connection targets for <a href="https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-1.0-specification.html#connect-src">connect-src</a>
-        are defined as a <a href="https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-1.0-specification.html#source-list">Source List</a> 
+        are defined as a <a href="https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-1.0-specification.html#source-list">Source List</a>
         and this assumes URI schemes. So, schemes for UDP and TCP, i.e. udp:
-        and tcp:, might have to be defined. See <a href="https://github.com/sysapps/tcp-udp-sockets/issues/17">address + port vs uri</a>. 
-      </p>   
-      
-    </section>       
-    
-<!------------------------ Interface Navigator  ------------------------------>        
+        and tcp:, might have to be defined. See <a href="https://github.com/sysapps/tcp-udp-sockets/issues/17">address + port vs uri</a>.
+      </p>
+
+    </section>
+
+<!------------------------ Interface Navigator  ------------------------------>
     <section>
       <h2><a>Navigator</a> Interface</h2>
        <dl title="partial interface Navigator" class="idl">
@@ -344,65 +344,65 @@ Style guide to contributors:
         <dt>readonly attribute TCPPermission tcpPermission</dt>
         <dd>
           The object that exposes permissions for access to the TCPSocket interface.
-        </dd>        
+        </dd>
         <dt>readonly attribute TCPServerPermission tcpServerPermission</dt>
         <dd>
           The object that exposes permissions for access to the TCPServerSocket interface.
-        </dd>        
+        </dd>
       </dl>
-    </section>    
-    
-<!------------------------ Interface UDPPermission  ------------------------------>  
+    </section>
+
+<!------------------------ Interface UDPPermission  ------------------------------>
     <section>
        <h2><a>UDPPermission</a> Interface</h2>
        <p>
          This interface exposes methods related to the permission to access
          the <a>UDPSocket</a> interface. Permission could be given based on user
-         consent, based on trust for the <a>webapp</a>, e.g. related to the 
-         origin of it and verified through web security mechanisms such as 
-         secure transport and signatures, based on previously granted or 
-         denied permission explicitly for this webapp or a combination of 
+         consent, based on trust for the <a>webapp</a>, e.g. related to the
+         origin of it and verified through web security mechanisms such as
+         secure transport and signatures, based on previously granted or
+         denied permission explicitly for this webapp or a combination of
          these mechanisms.
-       </p> 
-         
+       </p>
+
        <dl title="interface UDPPermission" class="idl">
-         
+
          <dt>
            Promise&lt;TCPUDPPermissionState&gt; hasPermission ()
          </dt>
          <dd>
-           Retrieves the permission state (<a>TCPUDPPermissionState</a>) of the 
-           requesting <a>webapp</a> for creating a <a>UDPSocket</a> object. The 
+           Retrieves the permission state (<a>TCPUDPPermissionState</a>) of the
+           requesting <a>webapp</a> for creating a <a>UDPSocket</a> object. The
            method returns a <a>Promise</a>, which is resolved with the permission
            state as argument.
            <p>
              This method MUST run the following steps asynchronously:
              <ol>
                <li>Create a new <a>Promise</a>, <code>udpPermissionPromise</code>,
-                   return it and run the remaining steps asynchronously.</li>                   
+                   return it and run the remaining steps asynchronously.</li>
                <li>Retrieve the permission state of the requesting <a>webapp</a>
-                   for creating a <a>UDPSocket</a> object according to the 
+                   for creating a <a>UDPSocket</a> object according to the
                    <code>udpPermissionOptions</code> argument.</li>
                <li>If there is an error, reject <code>udpPermissionPromise</code>
                    with no arguments and abort the remaining steps.</li>
                <li>When the request has been completed, resolve <code>udpPermissionPromise</code>
                    with <a>TCPUDPPermissionState</a> providing the permission
-                   state. </li>   
-             </ol>      
-           </p>             
-           
+                   state. </li>
+             </ol>
+           </p>
+
            <dl class='parameters'>
-               
+
              <dt>optional UDPPermissionOptions udpPermissionOptions</dt>
              <dd>
                Options for the permission state request. If this argument is
                omitted this is interpreted as described for <a>UDPPermissionOptions</a>
-               when all dictionary fields are ommitted. 
-             </dd>              
-                             
-           </dl>      
-           
-         </dd>    
+               when all dictionary fields are ommitted.
+             </dd>
+
+           </dl>
+
+         </dd>
 
          <dt>
            Promise&lt;void&gt; requestPermission ()
@@ -410,81 +410,81 @@ Style guide to contributors:
          <dd>
            Requests permission to create a <a>UDPSocket</a> object. The method
            returns a <a>Promise</a>, which is resolved if permission was given
-           and rejected if permission was denied. 
+           and rejected if permission was denied.
            <p>
              This method MUST run the following steps asynchronously:
              <ol>
                <li>Create a new <a>Promise</a>, <code>udpRequestPermissionPromise</code>,
-                   return it and run the remaining steps asynchronously.</li>                   
-               <li>If the requesting <a>webapp</a> is denied to create a 
-                   <a>UDPSocket</a> object that sends UDP packets to the requested 
+                   return it and run the remaining steps asynchronously.</li>
+               <li>If the requesting <a>webapp</a> is denied to create a
+                   <a>UDPSocket</a> object that sends UDP packets to the requested
                    remote address and port reject <code>tcpRequestPermissionPromise</code>
                    with DOMException <code>"SecurityError"</code> and
                    abort the remaining steps.</li>
-               <li>If the requesting <a>webapp</a> is denied to create a 
+               <li>If the requesting <a>webapp</a> is denied to create a
                    <a>UDPSocket</a> object that binds to the requested local
                    address and port reject <code>tcpRequestPermissionPromise</code>
                    with DOMException <code>"SecurityError"</code> and
-                   abort the remaining steps.</li>                   
-               <li>If the requesting <a>webapp</a> is allowed to create a 
+                   abort the remaining steps.</li>
+               <li>If the requesting <a>webapp</a> is allowed to create a
                    <a>UDPSocket</a> object without user interaction, e.g. based
-                   on a prearranged trust relationship or the user has already 
-                   granted permission explicitly for this <a>webapp</a>, resolve 
+                   on a prearranged trust relationship or the user has already
+                   granted permission explicitly for this <a>webapp</a>, resolve
                    <code>udpRequestPermissionPromise</code> and abort the remaining
                    steps.</li>
                <li>Request user consent to create a <a>UDPSocket</a> object.</li>
-               <li>If permission was granted, resolve <code>udpRequestPermissionPromise</code> 
-                   and abort the remaining steps.</li> 
+               <li>If permission was granted, resolve <code>udpRequestPermissionPromise</code>
+                   and abort the remaining steps.</li>
                <li>If permission was not granted, reject <code>udpRequestPermissionPromise</code>
-                   with DOMException <code>"SecurityError"</code>. </li>  
-             </ol>      
-           </p>             
-           
+                   with DOMException <code>"SecurityError"</code>. </li>
+             </ol>
+           </p>
+
            <dl class='parameters'>
-           
+
              <dt>optional UDPPermissionOptions udpPermissionOptions</dt>
              <dd>
-               Options for the permission request. If this argument is omitted 
+               Options for the permission request. If this argument is omitted
                this is interpreted as described for <a>UDPPermissionOptions</a>
-               when all dictionary fields are ommitted. 
-             </dd>                 
-                             
-           </dl>      
-           
-         </dd>    
+               when all dictionary fields are ommitted.
+             </dd>
 
-       </dl>                 
-      
-    </section>              
-    
-<!------------------------ Interface TCPPermission  ------------------------------>  
+           </dl>
+
+         </dd>
+
+       </dl>
+
+    </section>
+
+<!------------------------ Interface TCPPermission  ------------------------------>
     <section>
        <h2><a>TCPPermission</a> Interface</h2>
        <p>
          This interface exposes methods related to the permission to access
          the <a>TCPSocket</a> interface. Permission could be given based on user
-         consent, based on trust for the <a>webapp</a>, e.g. related to the 
-         origin of it and verified through web security mechanisms such as 
-         secure transport and signatures, based on previously granted or 
-         denied permission explicitly for this webapp or a combination of 
+         consent, based on trust for the <a>webapp</a>, e.g. related to the
+         origin of it and verified through web security mechanisms such as
+         secure transport and signatures, based on previously granted or
+         denied permission explicitly for this webapp or a combination of
          these mechanisms.
-       </p> 
-         
+       </p>
+
        <dl title="interface TCPPermission" class="idl">
-         
+
          <dt>
            Promise&lt;TCPUDPPermissionState&gt; hasPermission ()
          </dt>
          <dd>
-           Retrieves the permission state (<a>TCPUDPPermissionState</a>) of the 
-           requesting <a>webapp</a> for creating a <a>TCPSocket</a> object. The 
+           Retrieves the permission state (<a>TCPUDPPermissionState</a>) of the
+           requesting <a>webapp</a> for creating a <a>TCPSocket</a> object. The
            method returns a <a>Promise</a>, which is resolved with the permission
            state as argument.
            <p>
              This method MUST run the following steps asynchronously:
              <ol>
                <li>Create a new <a>Promise</a>, <code>tcpPermissionPromise</code>,
-                   return it and run the remaining steps asynchronously.</li>                   
+                   return it and run the remaining steps asynchronously.</li>
                <li>Retrieve the permission state of the requesting <a>webapp</a>
                    for creating a <a>TCPSocket</a> object that connects to the
                    requested remote address and port.</li>
@@ -492,126 +492,126 @@ Style guide to contributors:
                    with no arguments and abort the remaining steps.</li>
                <li>When the request has been completed, resolve <code>tcpPermissionPromise</code>
                    with <a>TCPUDPPermissionState</a> providing the permission
-                   state. </li>   
-             </ol>      
-           </p>             
-           
+                   state. </li>
+             </ol>
+           </p>
+
            <dl class='parameters'>
-               
+
             <dt>optional TCPPermissionOptions tcpPermissionOptions</dt>
              <dd>
                Options for the permission state request. If this argument is
                omitted this is interpreted as described for <a>TCPPermissionOptions</a>
-               when all dictionary fields are ommitted. 
-             </dd>                 
-                             
-           </dl>      
-           
-         </dd>    
+               when all dictionary fields are ommitted.
+             </dd>
+
+           </dl>
+
+         </dd>
 
          <dt>
            Promise&lt;void&gt; requestPermission ()
          </dt>
          <dd>
-           Requests permission to create a <a>TCPSocket</a> object that creates 
-           a connection to the requested remoteAddress and remotePort. The method 
-           returns a <a>Promise</a>, which is resolved if permission was given and 
-           rejected if permission was denied. 
+           Requests permission to create a <a>TCPSocket</a> object that creates
+           a connection to the requested remoteAddress and remotePort. The method
+           returns a <a>Promise</a>, which is resolved if permission was given and
+           rejected if permission was denied.
            <p>
              This method MUST run the following steps asynchronously:
              <ol>
                <li>Create a new <a>Promise</a>, <code>tcpRequestPermissionPromise</code>,
-                   return it and run the remaining steps asynchronously.</li>                   
-               <li>If the requesting <a>webapp</a> is denied to create a 
+                   return it and run the remaining steps asynchronously.</li>
+               <li>If the requesting <a>webapp</a> is denied to create a
                    <a>TCPSocket</a> object that connects to the requested remote
                    address and port reject <code>tcpRequestPermissionPromise</code>
                    with DOMException <code>"SecurityError"</code> and
                    abort the remaining steps.</li>
-               <li>If the requesting <a>webapp</a> is allowed to create a 
+               <li>If the requesting <a>webapp</a> is allowed to create a
                    <a>TCPSocket</a> object that connects to the requested remote
-                   address and port without user interaction, e.g. based on a 
+                   address and port without user interaction, e.g. based on a
                    prearranged trust relationship or the user has already granted
-                   permission explicitly for this <a>webapp</a>, resolve 
+                   permission explicitly for this <a>webapp</a>, resolve
                    <code>tcpRequestPermissionPromise</code> and abort the remaining
                    steps.</li>
-               <li>Request user consent to create a <a>TCPSocket</a> object 
+               <li>Request user consent to create a <a>TCPSocket</a> object
                    that connects to the requested remote address and port.</li>
-               <li>If permission was granted, resolve <code>tcpRequestPermissionPromise</code> 
-                   and abort the remaining steps.</li> 
+               <li>If permission was granted, resolve <code>tcpRequestPermissionPromise</code>
+                   and abort the remaining steps.</li>
                <li>If permission was not granted, reject <code>tcpRequestPermissionPromise</code>
-                   with DOMException <code>"SecurityError"</code>. </li>  
-             </ol>      
-           </p>             
-           
+                   with DOMException <code>"SecurityError"</code>. </li>
+             </ol>
+           </p>
+
            <dl class='parameters'>
-               
+
              <dt>optional TCPPermissionOptions tcpPermissionOptions</dt>
              <dd>
-               Options for the permission request. If this argument is omitted 
+               Options for the permission request. If this argument is omitted
                this is interpreted as described for <a>TCPPermissionOptions</a>
-               when all dictionary fields are ommitted. 
-             </dd>                  
-                             
-           </dl>      
-           
-         </dd>    
+               when all dictionary fields are ommitted.
+             </dd>
 
-       </dl>                 
-      
-    </section>       
-    
-<!------------------------ Interface TCPServerPermission  ------------------------------>  
+           </dl>
+
+         </dd>
+
+       </dl>
+
+    </section>
+
+<!------------------------ Interface TCPServerPermission  ------------------------------>
     <section>
        <h2><a>TCPServerPermission</a> Interface</h2>
        <p>
          This interface exposes methods related to the permission to access
-         the <a>TCPServerSocket</a> interface. Permission could be given based 
-         on user consent, based on trust for the <a>webapp</a>, e.g. related to 
-         the origin of it and verified through web security mechanisms such as 
-         secure transport and signatures, based on previously granted or 
-         denied permission explicitly for this webapp or a combination of 
+         the <a>TCPServerSocket</a> interface. Permission could be given based
+         on user consent, based on trust for the <a>webapp</a>, e.g. related to
+         the origin of it and verified through web security mechanisms such as
+         secure transport and signatures, based on previously granted or
+         denied permission explicitly for this webapp or a combination of
          these mechanisms.
-       </p> 
-         
+       </p>
+
        <dl title="interface TCPServerPermission" class="idl">
-         
+
          <dt>
            Promise&lt;TCPUDPPermissionState&gt; hasPermission ()
          </dt>
          <dd>
-           Retrieves the permission state (<a>TCPUDPPermissionState</a>) of the 
-           requesting <a>webapp</a> for creating a <a>TCPServerSocket</a> object. 
+           Retrieves the permission state (<a>TCPUDPPermissionState</a>) of the
+           requesting <a>webapp</a> for creating a <a>TCPServerSocket</a> object.
            The method returns a <a>Promise</a>, which is resolved with the
            permission state as argument.
            <p>
              This method MUST run the following steps asynchronously:
              <ol>
                <li>Create a new <a>Promise</a>, <code>tcpServerPermissionPromise</code>,
-                   return it and run the remaining steps asynchronously.</li>                   
+                   return it and run the remaining steps asynchronously.</li>
                <li>Retrieve the permission state of the requesting <a>webapp</a>
-                   for creating a <a>TCPServerSocket</a> object according to the 
+                   for creating a <a>TCPServerSocket</a> object according to the
                    <code>tcpServerPermissionOptions</code> argument.</li>
                <li>If there is an error, reject <code>tcpServerPermissionPromise</code>
                    with no arguments and abort the remaining steps.</li>
                <li>When the request has been completed, resolve <code>tcpServerPermissionPromise</code>
                    with <a>TCPUDPPermissionState</a> providing the permission
-                   state. </li>   
-             </ol>      
-           </p>             
-           
+                   state. </li>
+             </ol>
+           </p>
+
            <dl class='parameters'>
-               
+
              <dt>optional TCPServerPermissionOptions tcpServerPermissionOptions</dt>
              <dd>
                Options for the permission state request. If this argument is
                omitted this is interpreted as described for
-               <a>TCPServerPermissionOptions</a> when all dictionary fields are 
-               omitted. 
-             </dd>              
-                             
-           </dl>      
-           
-         </dd>    
+               <a>TCPServerPermissionOptions</a> when all dictionary fields are
+               omitted.
+             </dd>
+
+           </dl>
+
+         </dd>
 
          <dt>
            Promise&lt;void&gt; requestPermission ()
@@ -619,105 +619,101 @@ Style guide to contributors:
          <dd>
            Requests permission to create a <a>TCPServerSocket</a> object. The method
            returns a <a>Promise</a>, which is resolved if permission was given
-           and rejected if permission was denied. 
+           and rejected if permission was denied.
            <p>
              This method MUST run the following steps asynchronously:
              <ol>
                <li>Create a new <a>Promise</a>, <code>tcpServerRequestPermissionPromise</code>,
-                   return it and run the remaining steps asynchronously.</li>                   
-               <li>If the requesting <a>webapp</a> is denied to create a 
+                   return it and run the remaining steps asynchronously.</li>
+               <li>If the requesting <a>webapp</a> is denied to create a
                    <a>TCPServerSocket</a> object that binds to the requested local
                    address and port reject <code>tcpServerRequestPermissionPromise</code>
                    with DOMException <code>"SecurityError"</code> and
-                   abort the remaining steps.</li>                   
-               <li>If the requesting <a>webapp</a> is allowed to create a 
+                   abort the remaining steps.</li>
+               <li>If the requesting <a>webapp</a> is allowed to create a
                    <a>TCPServerSocket</a> object without user interaction, e.g. based
-                   on a prearranged trust relationship or the user has already 
-                   granted permission explicitly for this <a>webapp</a>, resolve 
-                   <code>tcpServerRequestPermissionPromise</code> and abort the 
+                   on a prearranged trust relationship or the user has already
+                   granted permission explicitly for this <a>webapp</a>, resolve
+                   <code>tcpServerRequestPermissionPromise</code> and abort the
                    remaining steps.</li>
                <li>Request user consent to create a <a>TCPServerSocket</a> object.</li>
-               <li>If permission was granted, resolve <code>tcpServerRequestPermissionPromise</code> 
-                   and abort the remaining steps.</li> 
+               <li>If permission was granted, resolve <code>tcpServerRequestPermissionPromise</code>
+                   and abort the remaining steps.</li>
                <li>If permission was not granted, reject <code>tcpServerRequestPermissionPromise</code>
-                   with DOMException <code>"SecurityError"</code>. </li>  
-             </ol>      
-           </p>             
-           
+                   with DOMException <code>"SecurityError"</code>. </li>
+             </ol>
+           </p>
+
            <dl class='parameters'>
-           
+
              <dt>optional TCPServerPermissionOptions tcpServerPermissionOptions</dt>
              <dd>
-               Options for the permission request. If this argument is omitted 
+               Options for the permission request. If this argument is omitted
                this is interpreted as described for <a>TCPServerPermissionOptions</a>
-               when all dictionary fields are ommitted. 
-             </dd>                 
-                             
-           </dl>      
-           
-         </dd>    
+               when all dictionary fields are ommitted.
+             </dd>
 
-       </dl>                 
-      
-    </section>                     
-    
-<!------------------------ Interface UDPSocket ------------------------------>        
+           </dl>
+
+         </dd>
+
+       </dl>
+
+    </section>
+
+<!------------------------ Interface UDPSocket ------------------------------>
     <section>
       <h2>Interface <a>UDPSocket</a></h2>
-      <p>The <a>UDPSocket</a> interface defines attributes and methods for 
-         UDP communication</p> 
-         
-      <pre class="example highlight"> 
-        // 
-        // This example shows a simple implementation of UPnP-SSDP M-SEARCH
-        // discovery using a multicast UDPSocket 
+      <p>The <a>UDPSocket</a> interface defines attributes and methods for
+         UDP communication</p>
+
+      <pre class="example highlight">
         //
-      
+        // This example shows a simple implementation of UPnP-SSDP M-SEARCH
+        // discovery using a multicast UDPSocket
+        //
+
         var address = '239.255.255.250',
             port = '1900',
             serviceType = 'upnp:rootdevice',
             rn = '\r\n',
             search = '';
-            
+
         //  Request permission to send multicast messages to the address and
-        //  port reserved for SSDP                       
-        navigator.udpPermission.requestPermission({remoteAddress:"239.255.255.250", 
+        //  port reserved for SSDP
+        navigator.udpPermission.requestPermission({remoteAddress:"239.255.255.250",
                                                    remotePort:1900}).then(
           () => {
-            // Permission was granted     
-          
+            // Permission was granted
+
             //  Create a new UDP client socket
             var mySocket = new UDPSocket();
-            
+
             // Build an SSDP M-SEARCH multicast message
             search += 'M-SEARCH * HTTP/1.1' + rn;
             search += 'ST: ' + serviceType + rn;
             search += 'MAN: "ssdp:discover"' + rn;
             search += 'HOST: ' + address + ':' + port + rn;
             search += 'MX: 10';
-            
-            
+
+
             // Receive and log SSDP M-SEARCH response messages
-            function receiveMSearchResponses() {         
-            
-              // While data in buffer, read and log UDP message
-              while (mySocket.readable.state === "readable") {            
-                var msg = mySocket.readable.read();
-                console.log ('Remote address: ' + msg.remoteAddress + 
-                             ' Remote port: ' + msg.remotePort + 
-                             'Message: ' + ab2str(msg.data)); 
-                  // ArrayBuffer to string conversion could also be done by piping 
-                  // through a transform stream. To be updated when the Streams API
-                  // specification has been stabilized on this point. 
-              }  
-                  
-              // Wait for SSDP M-SEARCH responses to arrive     
-              mySocket.readable.ready.then(receiveMSearchResponses);     
+            function receiveMSearchResponses() {
+              mySocket.readable.getReader().read().then(({ value, done }) => {
+                if (done) return;
+
+                console.log('Remote address: ' + value.remoteAddress +
+                            'Remote port: ' + value.remotePort +
+                            'Message: ' + ab2str(value.data));
+                // ArrayBuffer to string conversion could also be done by piping
+                // through a transform stream. To be updated when the Streams API
+                // specification has been stabilized on this point.
+              });
             }
-            
+
             // Join SSDP multicast group
             mySocket.joinMulticast(address);
-            
+
             // Send SSDP M-SEARCH multicast message
             mySocket.writeable.write(
               {data : str2ab(search),
@@ -731,543 +727,541 @@ Style guide to contributors:
                 },
                 e => console.error("Sending error: ", e);
             );
-            
-            // Log result of UDP socket setup. 
+
+            // Log result of UDP socket setup.
             mySocket.opened.then(
               () => {
                 console.log("UDP socket created sucessfully");
               },
               e =>console.error("UDP socket setup failed due to error: ", e);
             );
-            
-            // Handle UDP socket closed, either as a result of the application 
-            // calling mySocket.close() or an error causing the socket to be 
+
+            // Handle UDP socket closed, either as a result of the application
+            // calling mySocket.close() or an error causing the socket to be
             // closed.
             mySocket.closed.then(
               () => {
                  console.log("Socket has been cleanly closed");
               },
               e => console.error("Socket closed due to error: ", e);
-            );     
-          
+            );
+
           },
           e => console.error("Sending SSDP multicast messages was denied due
-                              to error: ", e);    
-        );              
+                              to error: ", e);
+        );
 
-      </pre>         
-         
+      </pre>
 
-      <dl title="[Constructor (optional UDPOptions options)] 
+
+      <dl title="[Constructor (optional UDPOptions options)]
                  interface UDPSocket"
-          class="idl">                           
+          class="idl">
 
         <dt>readonly attribute DOMString? localAddress</dt>
-        <dd>The IPv4/6 address of the local interface, e.g. wifi or 3G, that the 
-            UDPSocket object is bound to. Can be set by the constructor's 
-            <code>options</code> argument's <code>localAddress</code> member. If 
-            this member is not present but the <code>remoteAddress</code> member is 
-            present, the <a>user agent</a> binds the socket to a local IPv4/6 address 
-            based on the routing table and possiby a preselect default local 
-            interface to use for the selected <code>remoteAddress</code>. Else, 
-            i.e. neither the <code>localAddress</code> or the 
-            <code>remoteAddress</code> members are present in the constructor's 
-            <code>options</code> argument, the <code>localAddress</code> 
-            attribute is set to <code>null</code>.</dd>   
-        
+        <dd>The IPv4/6 address of the local interface, e.g. wifi or 3G, that the
+            UDPSocket object is bound to. Can be set by the constructor's
+            <code>options</code> argument's <code>localAddress</code> member. If
+            this member is not present but the <code>remoteAddress</code> member is
+            present, the <a>user agent</a> binds the socket to a local IPv4/6 address
+            based on the routing table and possiby a preselect default local
+            interface to use for the selected <code>remoteAddress</code>. Else,
+            i.e. neither the <code>localAddress</code> or the
+            <code>remoteAddress</code> members are present in the constructor's
+            <code>options</code> argument, the <code>localAddress</code>
+            attribute is set to <code>null</code>.</dd>
+
         <dt>readonly attribute unsigned short? localPort</dt>
-        <dd>The local port that the UDPSocket object is bound to. Can be set by 
+        <dd>The local port that the UDPSocket object is bound to. Can be set by
             the <code>options</code> argument in the constructor. If not set the
-            <a>user agent</a> binds the socket to an ephemeral local port decided by 
-            the system and this attribute is null. </dd>             
+            <a>user agent</a> binds the socket to an ephemeral local port decided by
+            the system and this attribute is null. </dd>
 
         <dt>readonly attribute DOMString? remoteAddress</dt>
-        <dd>The default remote host name or IPv4/6 address that is used for 
+        <dd>The default remote host name or IPv4/6 address that is used for
             subsequent send() calls. Null if not stated by the options argument
-            of the constructor.</dd>   
-        
+            of the constructor.</dd>
+
         <dt>readonly attribute unsigned short? remotePort</dt>
         <dd>The default remote port that is used for subsequent send() calls.
-            Null if not stated by the options argument of the constructor</dd>  
-            
+            Null if not stated by the options argument of the constructor</dd>
+
         <dt>readonly attribute boolean addressReuse</dt>
-        <dd><code>true</code> allows the socket to be bound to a local address/port 
-            pair that already is in use. Can be set by the <code>options</code> 
+        <dd><code>true</code> allows the socket to be bound to a local address/port
+            pair that already is in use. Can be set by the <code>options</code>
             argument in the constructor. Default is <code>true</code>.</dd>
-            
+
         <dt>readonly attribute boolean loopback</dt>
-        <dd>Only applicable for multicast. <code>true</code> means that sent 
-            multicast data is looped back to the sender.           
-            Can be set by the <code>options</code> argument in the constructor.  
-            Default is <code>false</code>.</dd>                          
-        
+        <dd>Only applicable for multicast. <code>true</code> means that sent
+            multicast data is looped back to the sender.
+            Can be set by the <code>options</code> argument in the constructor.
+            Default is <code>false</code>.</dd>
+
         <dt>readonly attribute SocketReadyState readyState</dt>
-        <dd>The state of the UDP Socket object. A UDP Socket object can be in "open" 
-            "opening" or "closed" states. See enum <a>SocketReadyState</a> for details. </dd> 
-            
+        <dd>The state of the UDP Socket object. A UDP Socket object can be in "open"
+            "opening" or "closed" states. See enum <a>SocketReadyState</a> for details. </dd>
+
         <dt> readonly attribute Promise opened</dt>
-        <dd> Detects the result of the UDP socket creation attempt. Returns 
-             the <code>openedPromise</code> that was created in the 
-             <code>UDPSocket</code> constructor.    
-        </dd>  
-        
+        <dd> Detects the result of the UDP socket creation attempt. Returns
+             the <code>openedPromise</code> that was created in the
+             <code>UDPSocket</code> constructor.
+        </dd>
+
         <dt> readonly attribute Promise closed</dt>
-        <dd> Detects when the UDP socket has been closed, either cleanly by 
-             the <a>webapp</a> calling <code>close()</code>) or 
+        <dd> Detects when the UDP socket has been closed, either cleanly by
+             the <a>webapp</a> calling <code>close()</code>) or
              through an error situation, e.g. network contact lost.
-             Returns the <code>closedPromise</code> that was created 
-             in the <code>UDPSocket</code> constructor.    
-        </dd>                                      
-         
+             Returns the <code>closedPromise</code> that was created
+             in the <code>UDPSocket</code> constructor.
+        </dd>
+
         <dt>readonly attribute ReadableStream readable</dt>
-        <dd>The object that represents the UDP socket's source of data, from which 
-            you can read. [[!STREAMS]] </dd>     
-            
+        <dd>The object that represents the UDP socket's source of data, from which
+            you can read. [[!STREAMS]] </dd>
+
         <dt>readonly attribute WriteableStream writeable</dt>
-        <dd>The object that represents the UDP socket's destination for data, 
-            into which you can write. [[!STREAMS]] </dd>               
+        <dd>The object that represents the UDP socket's destination for data,
+            into which you can write. [[!STREAMS]] </dd>
 
         <dt> Promise close()</dt>
-        <dd>        
-          <p>Closes the UDP socket. Returns the <code>closedPromise</code> that 
-             was created in the <code>UDPSocket</code> constructor. </p>        
-        </dd>   
-        
+        <dd>
+          <p>Closes the UDP socket. Returns the <code>closedPromise</code> that
+             was created in the <code>UDPSocket</code> constructor. </p>
+        </dd>
+
         <dt> void joinMulticast()</dt>
-        <dd>        
-          <p>Joins a multicast group identified by the given address.</p>      
-          <p>Note that even if the socket is only sending to a multicast address, 
-             it is a good practice to explicitely join the multicast group 
-             (otherwise some routers may not relay packets).</p>              
-        
+        <dd>
+          <p>Joins a multicast group identified by the given address.</p>
+          <p>Note that even if the socket is only sending to a multicast address,
+             it is a good practice to explicitely join the multicast group
+             (otherwise some routers may not relay packets).</p>
+
           <dl class='parameters'>
-                     
+
              <dt>DOMString multicastGroupAddress</dt>
              <dd>
-               The multicast group address. 
-             </dd> 
-              
-          </dl>            
-                   
-        </dd>           
-        
-        <dt> void leaveMulticast()</dt>
-        <dd>        
-          <p>Leaves a multicast group membership identified by the given address.</p>             
-        
-          <dl class='parameters'>
-                     
-             <dt>DOMString multicastGroupAddress</dt>
-             <dd>
-               The multicast group address. 
-             </dd> 
-              
+               The multicast group address.
+             </dd>
+
           </dl>
-                   
-        </dd>                                                                                                           
-                            
-      </dl>     
- 
-      <p>When the <a>UDPSocket</a> constructor is invoked, the <a>user agent</a> 
-         MUST run the following steps:        
+
+        </dd>
+
+        <dt> void leaveMulticast()</dt>
+        <dd>
+          <p>Leaves a multicast group membership identified by the given address.</p>
+
+          <dl class='parameters'>
+
+             <dt>DOMString multicastGroupAddress</dt>
+             <dd>
+               The multicast group address.
+             </dd>
+
+          </dl>
+
+        </dd>
+
+      </dl>
+
+      <p>When the <a>UDPSocket</a> constructor is invoked, the <a>user agent</a>
+         MUST run the following steps:
         <ol>
          <li>Create a new UDPSocket object ("<code>mySocket</code>").
-         <li>If the <a>webapp</a> does not have permission to create a 
+         <li>If the <a>webapp</a> does not have permission to create a
              <a>UDPSocket</a> object according to the <code>options</code>
              argument then throw DOMException <code>"SecurityError"</code> and
-             abort the remaining steps.                          
-         <li>If the <code>options</code> argument's <code>remoteAddress</code> 
-             member is present and it is a valid host name or IPv4/6 address 
-             then set the <code>mySocket.remoteAddress</code> attribute 
-             (default remote address) to the requested address. Else, if the 
-             <code>remoteAddress</code> member is present but it is not a 
-             valid host name or IPv4/6 address then throw DOMException 
+             abort the remaining steps.
+         <li>If the <code>options</code> argument's <code>remoteAddress</code>
+             member is present and it is a valid host name or IPv4/6 address
+             then set the <code>mySocket.remoteAddress</code> attribute
+             (default remote address) to the requested address. Else, if the
+             <code>remoteAddress</code> member is present but it is not a
+             valid host name or IPv4/6 address then throw DOMException
              <code>InvalidAccessError</code> and abort the remaining
              steps.
-             Otherwise, if the <code>options</code> argument's <code>remoteAddress</code> 
-             member is absent then set the <code>mySocket.remoteAddress</code> 
-             attribute (default remote address) to <code>null</code>. 
-         <li>If the <code>options</code> argument's <code>remotePort</code> member 
-             is present and it is  a valid port number then set the 
-             <code>mySocket.remotePort</code> attribute (default remote port) 
-             to the requested port. Else, if the <code>remotePort</code> member 
-             is present but it is not a valid port number then throw DOMException 
+             Otherwise, if the <code>options</code> argument's <code>remoteAddress</code>
+             member is absent then set the <code>mySocket.remoteAddress</code>
+             attribute (default remote address) to <code>null</code>.
+         <li>If the <code>options</code> argument's <code>remotePort</code> member
+             is present and it is  a valid port number then set the
+             <code>mySocket.remotePort</code> attribute (default remote port)
+             to the requested port. Else, if the <code>remotePort</code> member
+             is present but it is not a valid port number then throw DOMException
              <code>InvalidAccessError</code> and abort the remaining steps.
-             Otherwise, if the <code>options</code> argument's <code>remotePort</code> 
-             member is absent then set the <code>mySocket.remotePort</code> 
-             attribute (default port number) to <code>null</code>.                       
-         <li>If the <code>options</code> argument's <code>localAddress</code> 
-             member is present and the <code>options</code> argument's 
-             <code>remoteAddress</code> member is present, execute the following 
+             Otherwise, if the <code>options</code> argument's <code>remotePort</code>
+             member is absent then set the <code>mySocket.remotePort</code>
+             attribute (default port number) to <code>null</code>.
+         <li>If the <code>options</code> argument's <code>localAddress</code>
+             member is present and the <code>options</code> argument's
+             <code>remoteAddress</code> member is present, execute the following
              step:
              <ul>
-               <li>If the <code>options</code> argument's <code>localAddress</code> 
-                   member is a valid IPv4/6 address for a local interface that can 
-                   be used to connect to the selected <code>remoteAddress</code> 
-                   (according to the routing table) bind the socket to this local 
-                   IPv4/6 address and set the <code>mySocket.localAddress</code> 
-                   attribute to this addres. Else, if the <code>localAddress</code> 
-                   member is present but it is not a valid local IPv4/6 address 
-                   for a local interface that can be used to connect to the 
-                   selected <code>remoteAddress</code>, throw DOMException 
-                   <code>InvalidAccessError</code> and abort the remaining 
-                   steps.             
-             </ul>   
-             Else, if the <code>options</code> argument's <code>localAddress</code> 
-             member is present and the <code>options</code> argument's 
-             <code>remoteAddress</code> member is absent, execute the following 
+               <li>If the <code>options</code> argument's <code>localAddress</code>
+                   member is a valid IPv4/6 address for a local interface that can
+                   be used to connect to the selected <code>remoteAddress</code>
+                   (according to the routing table) bind the socket to this local
+                   IPv4/6 address and set the <code>mySocket.localAddress</code>
+                   attribute to this addres. Else, if the <code>localAddress</code>
+                   member is present but it is not a valid local IPv4/6 address
+                   for a local interface that can be used to connect to the
+                   selected <code>remoteAddress</code>, throw DOMException
+                   <code>InvalidAccessError</code> and abort the remaining
+                   steps.
+             </ul>
+             Else, if the <code>options</code> argument's <code>localAddress</code>
+             member is present and the <code>options</code> argument's
+             <code>remoteAddress</code> member is absent, execute the following
              step:
              <ul>
-               <li>If the <code>options</code> argument's <code>localAddress</code> 
-                   member is a valid IPv4/6 address for a local interface on the 
-                   device bind the socket to this local IPv4/6 address and set the 
-                   <code>mySocket.localAddress</code> attribute to this addres. 
-                   Else, if the <code>localAddress</code> member is present but 
-                   it is not a valid local IPv4/6 address for a local interface 
-                   on the device, throw DOMException <code>InvalidAccessError</code> 
-                   and abort the remaining steps. Note that binding the UDPSocket 
-                   to a certain local interface means that the socket can only be 
-                   used to send UDP datagrams to peers reachable through this 
-                   local interface.            
-             </ul>  
-             Else, if the <code>options</code> argument's <code>localAddress</code> 
-             member is absent, and the <code>options</code> argument's 
-             <code>remoteAddress</code> member is present, execute the following 
-             steps: 
+               <li>If the <code>options</code> argument's <code>localAddress</code>
+                   member is a valid IPv4/6 address for a local interface on the
+                   device bind the socket to this local IPv4/6 address and set the
+                   <code>mySocket.localAddress</code> attribute to this addres.
+                   Else, if the <code>localAddress</code> member is present but
+                   it is not a valid local IPv4/6 address for a local interface
+                   on the device, throw DOMException <code>InvalidAccessError</code>
+                   and abort the remaining steps. Note that binding the UDPSocket
+                   to a certain local interface means that the socket can only be
+                   used to send UDP datagrams to peers reachable through this
+                   local interface.
+             </ul>
+             Else, if the <code>options</code> argument's <code>localAddress</code>
+             member is absent, and the <code>options</code> argument's
+             <code>remoteAddress</code> member is present, execute the following
+             steps:
              <ol>
                <li> Use the routing table to determine the local interface(s) that
-                    can be used to send datagrams to the selected 
-                    <code>remoteAddress</code>. If no local interface can be used 
-                    to send datagrams to the selected <code>remoteAddress</code>, 
-                    throw DOMException <code>InvalidAccessError</code> and 
+                    can be used to send datagrams to the selected
+                    <code>remoteAddress</code>. If no local interface can be used
+                    to send datagrams to the selected <code>remoteAddress</code>,
+                    throw DOMException <code>InvalidAccessError</code> and
                     abort the remaining steps.
-               <li> If the routing table states that more than one local interface 
-                    can be used to send datagrams to the selected 
-                    <code>remoteAddress</code> bind the socket to the IPv4/6 address 
-                    of the "default" local interface to use for the selected 
-                    <code>remoteAddress</code>. The selection of a "default" local 
+               <li> If the routing table states that more than one local interface
+                    can be used to send datagrams to the selected
+                    <code>remoteAddress</code> bind the socket to the IPv4/6 address
+                    of the "default" local interface to use for the selected
+                    <code>remoteAddress</code>. The selection of a "default" local
                     interface is out of scope for this specification.
-               <li> Set the <code>mySocket.localAddress</code> attribute to the 
-                    local address that the socket is bound to.             
-             </ol>   
-             Else, i.e. the <code>options</code> argument's <code>localAddress</code> 
-             member is absent, and the <code>options</code> argument's 
-             <code>remoteAddress</code> member is absent, execute the following 
-             step: 
+               <li> Set the <code>mySocket.localAddress</code> attribute to the
+                    local address that the socket is bound to.
+             </ol>
+             Else, i.e. the <code>options</code> argument's <code>localAddress</code>
+             member is absent, and the <code>options</code> argument's
+             <code>remoteAddress</code> member is absent, execute the following
+             step:
              <ul>
-               <li>                             
-                 Set the <code>mySocket.localAddress</code> attribute to 
+               <li>
+                 Set the <code>mySocket.localAddress</code> attribute to
                  <code>null</code>.
-             </ul>             
-         <li>If the <code>options</code> argument's <code>localPort</code> member 
-             is absent then bind the socket to an ephemeral local port decided 
-             by the system and set the <code>mySocket.localPort</code> attribute 
-             to null. 
-             Otherwise, bind the socket to the requested local port and set the 
-             <code>mySocket.localPort</code> attribute to the local port that 
-             the socket is bound to.             
-         <li>Set the <code>mySocket.addressReuse</code> attribute to the value 
-             of the <code>options</code> argument's <code>addressReuse</code> 
-             member if it is present or to <code>true</code> if the <code>options</code> 
-             argument's <code>addressReuse</code> member is not present.                  
-         <li>If the <code>options</code> argument's <code>loopback</code> member 
-             is present then set the <code>mySocket.loopback</code> attribute 
-             to the value of this field. Else set this attribute to <code>false</code>.   
-         <li>Set the <code>mySocket.readyState</code> attribute to "opening".           
-         <li>Create a new promise, "<code>openedPromise</code>", and store 
-             it so it can later be returned by the <code>opened</code> 
-             property.    
-         <li>Create a new promise, "<code>closedPromise</code>", and store 
-             it so it can later be returned by the <code>closed</code> 
-             property and the <code>close</code> method.            
+             </ul>
+         <li>If the <code>options</code> argument's <code>localPort</code> member
+             is absent then bind the socket to an ephemeral local port decided
+             by the system and set the <code>mySocket.localPort</code> attribute
+             to null.
+             Otherwise, bind the socket to the requested local port and set the
+             <code>mySocket.localPort</code> attribute to the local port that
+             the socket is bound to.
+         <li>Set the <code>mySocket.addressReuse</code> attribute to the value
+             of the <code>options</code> argument's <code>addressReuse</code>
+             member if it is present or to <code>true</code> if the <code>options</code>
+             argument's <code>addressReuse</code> member is not present.
+         <li>If the <code>options</code> argument's <code>loopback</code> member
+             is present then set the <code>mySocket.loopback</code> attribute
+             to the value of this field. Else set this attribute to <code>false</code>.
+         <li>Set the <code>mySocket.readyState</code> attribute to "opening".
+         <li>Create a new promise, "<code>openedPromise</code>", and store
+             it so it can later be returned by the <code>opened</code>
+             property.
+         <li>Create a new promise, "<code>closedPromise</code>", and store
+             it so it can later be returned by the <code>closed</code>
+             property and the <code>close</code> method.
 
-         <li>Let the <code>mySocket.readable</code> attribute be a new 
-             ReadableStream object, [[!STREAMS]]. The <a>user agent</a> MUST implement 
-             the adaptation layer to [[!STREAMS]] for this new ReadableStream 
-             object through implementation of a number of functions that are 
-             given as input arguments to the constructor and called by the 
-             [[!STREAMS]] implementation. The semantics for these 
+         <li>Let the <code>mySocket.readable</code> attribute be a new
+             ReadableStream object, [[!STREAMS]]. The <a>user agent</a> MUST implement
+             the adaptation layer to [[!STREAMS]] for this new ReadableStream
+             object through implementation of a number of functions that are
+             given as input arguments to the constructor and called by the
+             [[!STREAMS]] implementation. The semantics for these
              functions are described below:
 
-             <ul> 
-               <li>The constructor's <code>start()</code> function is called 
-                   immediately by the [[!STREAMS]] implementation. 
+             <ul>
+               <li>The constructor's <code>start()</code> function is called
+                   immediately by the [[!STREAMS]] implementation.
                    The <code>start()</code> function MUST run the following steps:
                    <ol>
-                     <li>Setup the UDP socket to the bound local and remote 
-                         address/port pairs in the background (without blocking 
-                         scripts) and return <code>openedPromise</code>. 
+                     <li>Setup the UDP socket to the bound local and remote
+                         address/port pairs in the background (without blocking
+                         scripts) and return <code>openedPromise</code>.
                      <li>When the UDP socket has been successfully setup
-                         the following steps MUST run:      
+                         the following steps MUST run:
                        <ol>
-                         <li>Change the <code>mySocket.readyState</code> 
-                             attribute's value to "open".    
+                         <li>Change the <code>mySocket.readyState</code>
+                             attribute's value to "open".
                          <li>Resolve <code>openedPromise</code> with
                              <code>undefined</code>.
                        </ol>
-                   </ol>                       
-                   The following internal methods of the ReadableStream are 
-                   arguments of the constructor's <code>start()</code> function 
-                   and MUST be called by the  <code>start()</code> function 
+                   </ol>
+                   The following internal methods of the ReadableStream are
+                   arguments of the constructor's <code>start()</code> function
+                   and MUST be called by the  <code>start()</code> function
                    implementation according to the  following steps:
-                   <ul>                     
-                     <li>The <code>enqueue()</code> argument of <code>start()</code> 
-                         is a function that pushes received data into the 
+                   <ul>
+                     <li>The <code>enqueue()</code> argument of <code>start()</code>
+                         is a function that pushes received data into the
                          internal buffer. <br>
-                         When a new UDP datagram has been received the following 
+                         When a new UDP datagram has been received the following
                          steps MUST run:
-                         <ol>                                 
+                         <ol>
                            <li>Create a new instance of <a>UDPMessage</a>.
-                           <li>Set the <a>UDPMessage</a> object's 
-                               <code>data</code> member to a new read-only 
-                               <code>ArrayBuffer</code> object whose contents 
-                               are the received UDP datagram [[!TYPED-ARRAYS]].             
-                           <li>Set the <code>remoteAddress</code> member of 
-                               the <a>UDPMessage</a> object to the source 
-                               address of the received UDP datagram.    
-                           <li>Set the <code>remotePort</code> member of the 
-                               <a>UDPMessage</a> object to the source port 
-                               of the received UDP datagram.                                            
+                           <li>Set the <a>UDPMessage</a> object's
+                               <code>data</code> member to a new read-only
+                               <code>ArrayBuffer</code> object whose contents
+                               are the received UDP datagram [[!TYPED-ARRAYS]].
+                           <li>Set the <code>remoteAddress</code> member of
+                               the <a>UDPMessage</a> object to the source
+                               address of the received UDP datagram.
+                           <li>Set the <code>remotePort</code> member of the
+                               <a>UDPMessage</a> object to the source port
+                               of the received UDP datagram.
                            <li>Call <code>enqueue()</code> to push the
-                               <a>UDPMessage</a> object into the internal 
-                               [[!STREAMS]] receive buffer. 
-                               Note that <code>enqueue()</code> returns false if 
+                               <a>UDPMessage</a> object into the internal
+                               [[!STREAMS]] receive buffer.
+                               Note that <code>enqueue()</code> returns false if
                                the high watermark of the buffer is reached.
                                However, as there is no flow control mechanism
                                in UDP the flow of datagrams can't be stopped.
-                               The <code>enqueue()</code> return value should 
+                               The <code>enqueue()</code> return value should
                                therefore be ignored. This means that datagrams
-                               will be lost if the internal receive buffer 
+                               will be lost if the internal receive buffer
                                has been filled to it's memory limit but
                                this is the nature of an unreliable protocol
-                               as UDP.         
-                         </ol>                                                                               
-                      <li>The <code>error()</code> argument of <code>start()</code> 
-                          is a function that handles readable stream errors and 
-                          closes the readble stream.<br> 
-                          Upon detection that the attempt to setup a new UDP 
+                               as UDP.
+                         </ol>
+                      <li>The <code>error()</code> argument of <code>start()</code>
+                          is a function that handles readable stream errors and
+                          closes the readble stream.<br>
+                          Upon detection that the attempt to setup a new UDP
                           socket (<code>mySocket.readyState</code> is "opening")
-                          has failed, e.g. because the local address/port pair is 
+                          has failed, e.g. because the local address/port pair is
                           already in use and <code>mySocket.addressReuse</code>
-                          is <code>false</code>, the following steps MUST run:      
-                          <ol>                                               
-                            <li>Call <code>error()</code> with DOMException 
+                          is <code>false</code>, the following steps MUST run:
+                          <ol>
+                            <li>Call <code>error()</code> with DOMException
                                 <code>"NetworkError"</code>.
-                            <li>Reject <code>openedPromise</code> with DOMException 
-                                <code>"NetworkError"</code>.   
-                            <li>Reject <code>closedPromise</code> with DOMException 
-                                <code>"NetworkError"</code>.             
-                            <li>Change the <code>mySocket.readyState</code> 
-                                attribute's value to "closed" and release any 
-                                underlying resources associated with this socket.                                                               
-                          </ol> 
-                          Upon detection that there is an error with the 
-                          established UDP socket (<code>mySocket.readyState</code> 
-                          is "open"), e.g. network connection is lost, the 
-                          following steps MUST run:      
-                          <ol>                                                 
-                            <li>Call <code>error()</code> with DOMException 
-                                <code>"NetworkError"</code>. 
-                            <li>Reject <code>closedPromise</code> with 
-                                DOMException <code>"NetworkError"</code>.                                                                  
-                            <li>Change the <code>mySocket.readyState</code> 
-                                attribute's value to "closed" and release any 
-                                underlying resources associated with this 
-                                socket.                               
-                          </ol>   
-                          When a new UDP datagram has been received and upon 
-                          detction that it is not possible to convert the 
-                          received UDP data to <code>ArrayBuffer</code>, 
+                            <li>Reject <code>openedPromise</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Reject <code>closedPromise</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Change the <code>mySocket.readyState</code>
+                                attribute's value to "closed" and release any
+                                underlying resources associated with this socket.
+                          </ol>
+                          Upon detection that there is an error with the
+                          established UDP socket (<code>mySocket.readyState</code>
+                          is "open"), e.g. network connection is lost, the
+                          following steps MUST run:
+                          <ol>
+                            <li>Call <code>error()</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Reject <code>closedPromise</code> with
+                                DOMException <code>"NetworkError"</code>.
+                            <li>Change the <code>mySocket.readyState</code>
+                                attribute's value to "closed" and release any
+                                underlying resources associated with this
+                                socket.
+                          </ol>
+                          When a new UDP datagram has been received and upon
+                          detction that it is not possible to convert the
+                          received UDP data to <code>ArrayBuffer</code>,
                           [[!TYPED-ARRAYS]], the following steps MUST run:
                           <ol>
-                            <li>Call <code>error()</code> with <code>TypeError</code>. 
-                            <li>Reject <code>closedPromise</code> with 
-                                <code>TypeError</code>.                                                                  
-                            <li>Change the <code>mySocket.readyState</code> 
-                                attribute's value to "closed" and release any 
-                                underlying resources associated with this 
-                                socket. 
-                          </ol>                        
-                           
-                   </ul>                  
+                            <li>Call <code>error()</code> with <code>TypeError</code>.
+                            <li>Reject <code>closedPromise</code> with
+                                <code>TypeError</code>.
+                            <li>Change the <code>mySocket.readyState</code>
+                                attribute's value to "closed" and release any
+                                underlying resources associated with this
+                                socket.
+                          </ol>
+
+                   </ul>
                  <li>The constructor's <code>pull()</code> function MUST be omitted
                      as there is no flow control mechanism in UDP and the flow
-                     of datagrams cannot be stopped and started again.                      
-                 <li>The constructor's <code>cancel()</code> function input 
-                     argument is called by the [[!STREAMS]] implementation when 
+                     of datagrams cannot be stopped and started again.
+                 <li>The constructor's <code>cancel()</code> function input
+                     argument is called by the [[!STREAMS]] implementation when
                      the ReadbleStream should be canceled. For UDP this means that
                      the UDP socket should be closed for reading and writing.
-                     The <code>cancel()</code> function MUST run the following steps:  
+                     The <code>cancel()</code> function MUST run the following steps:
                      <ol>
-                       <li>If <code>mySocket.readyState</code> is "closed" then 
-                           do nothing and abort the remaning steps.    
-                       <li>If <code>mySocket.readyState</code> is "opening" 
+                       <li>If <code>mySocket.readyState</code> is "closed" then
+                           do nothing and abort the remaning steps.
+                       <li>If <code>mySocket.readyState</code> is "opening"
                            then fail the UDP socket setup process, reject <code>openedPromise</code>
-                           with DOMException <code>AbortError</code> and set the 
+                           with DOMException <code>AbortError</code> and set the
                            <code>mySocket.readyState</code> attribute to "closed".
-                       <li>If <code>mySocket.readyState</code> is "open" the the 
+                       <li>If <code>mySocket.readyState</code> is "open" the the
                            following steps MUST run:
-                           <ol>  
-                             <li>Call <code>mySocket.writeable.close()</code> to 
-                                 assure that any buffered send data is sent.  
-                             <li>Set the <code>mySocket.readyState</code> 
-                                 attribute's value to "closed".  
-                             <li>Resolve <code>closedPromise</code> with 
-                                 <code>undefined</code> and release any 
-                                underlying resources associated with this 
-                                socket.    
-                           </ol>       
-                     </ol>                   
-                     
+                           <ol>
+                             <li>Call <code>mySocket.writeable.close()</code> to
+                                 assure that any buffered send data is sent.
+                             <li>Set the <code>mySocket.readyState</code>
+                                 attribute's value to "closed".
+                             <li>Resolve <code>closedPromise</code> with
+                                 <code>undefined</code> and release any
+                                underlying resources associated with this
+                                socket.
+                           </ol>
+                     </ol>
+
                  <p class="issue">
                    If the constructor's <code>strategy</code> argument is
-                   omitted the 
-                   <a href= "https://streams.spec.whatwg.org/#default-rs-strategy">Default strategy for Readable Streams</a> 
-                   applies. Currently this means that the ReadableStream 
-                   object goes to "readable" state after 1 chunk has been 
-                   enqueued to the internal ReadableStream object's input
-                   buffer. A <a>webapp</a> should use .ready to be notified 
-                   when the state changes to "readable". To be further 
-                   investigated which ReadableStreamStrategy that should 
+                   omitted the default backpressure behavior of readable streams
+                   applies. Currently this means that the ReadableStream object
+                   begins applying backpressure after 1 chunk has been enqueued
+                   to the internal ReadableStream object's input buffer. To be
+                   further investigated which readable stream strategy that should
                    be applied to UDP.
-                 </p>                         
-             </ul>                   
-                    
-         <li>Let the <code>mySocket.writeable</code> attribute be a new 
-             WritableStream object, [[!STREAMS]]. The <a>user agent</a> MUST implement 
-             the adaptation layer to [[!STREAMS]] for this new WritableStream 
-             object through implementation of a number of functions that are 
-             given as input arguments to the constructor and called by the 
-             [[!STREAMS]] implementation. The semantics for these 
+                 </p>
+             </ul>
+
+         <li>Let the <code>mySocket.writeable</code> attribute be a new
+             WritableStream object, [[!STREAMS]]. The <a>user agent</a> MUST implement
+             the adaptation layer to [[!STREAMS]] for this new WritableStream
+             object through implementation of a number of functions that are
+             given as input arguments to the constructor and called by the
+             [[!STREAMS]] implementation. The semantics for these
              functions are described below:
-                          
-             <ul> 
+
+             <ul>
                <li>The constructor's <code>start()</code> function MUST run the
                    following steps:
                    <ol>
                      <li>Create a new promise, "<code>writableStartPromise</code>".
-                     <li>If the attempt to create a new UDP socket (see the 
-                         description of the semantics for the <code>mySocket.readable</code> 
-                         attribute constructor's <code>start()</code> function ) 
+                     <li>If the attempt to create a new UDP socket (see the
+                         description of the semantics for the <code>mySocket.readable</code>
+                         attribute constructor's <code>start()</code> function )
                          succeded resolve <code>writableStartPromise</code>
-                         with <code>undefined</code>, else reject <code>writableStartPromise</code> 
-                         with DOMException <code>"NetworkError"</code>.   
-                   </ol>                                          
-               <li>The constructor's <code>write(chunk)</code> 
-                   function is called by the [[!STREAMS]] implementation to 
-                   write UDP data. The <code>write()</code> 
+                         with <code>undefined</code>, else reject <code>writableStartPromise</code>
+                         with DOMException <code>"NetworkError"</code>.
+                   </ol>
+               <li>The constructor's <code>write(chunk)</code>
+                   function is called by the [[!STREAMS]] implementation to
+                   write UDP data. The <code>write()</code>
                    function MUST run the following steps:
                    <ol>
                      <li>Create a new promise, "<code>writePromise</code>"
-                     <li>Convert the <code>chunk</code> argument to a 
-                         <a>UDPMessage</a> object (per [[!WEBIDL]] dictionary 
+                     <li>Convert the <code>chunk</code> argument to a
+                         <a>UDPMessage</a> object (per [[!WEBIDL]] dictionary
                          conversion).
-                     <li>If no default remote address was specified in the 
-                         UDPSocket's constructor <code>options</code> argument's 
-                         <code>remoteAddress</code> member and the 
-                         <a>UDPMessage</a> object's <code>remoteAddress</code> 
-                         member is not present or null then throw DOMException 
-                         <code>InvalidAccessError</code> and abort these steps.   
-                     <li>If no default remote port was specified in the 
-                         UDPSocket's constructor <code>options</code> argument's 
-                         <code>remotePort</code> member and the 
-                         <a>UDPMessage</a> object's <code>remotePort</code> 
-                         member is not present or null then throw DOMException 
-                         <code>InvalidAccessError</code> and abort these steps.  
-                     <li>If the <a>UDPMesssage</a> object's <code>remoteAddress</code> 
+                     <li>If no default remote address was specified in the
+                         UDPSocket's constructor <code>options</code> argument's
+                         <code>remoteAddress</code> member and the
+                         <a>UDPMessage</a> object's <code>remoteAddress</code>
+                         member is not present or null then throw DOMException
+                         <code>InvalidAccessError</code> and abort these steps.
+                     <li>If no default remote port was specified in the
+                         UDPSocket's constructor <code>options</code> argument's
+                         <code>remotePort</code> member and the
+                         <a>UDPMessage</a> object's <code>remotePort</code>
+                         member is not present or null then throw DOMException
+                         <code>InvalidAccessError</code> and abort these steps.
+                     <li>If the <a>UDPMesssage</a> object's <code>remoteAddress</code>
                          and/or <code>remotePort</code> member(s) are present but
                          the <a>webapp</a> does not have permission to send UDP
-                         packets to this address and port then throw DOMException 
-                         <code>SecurityError</code> and abort these steps.                      
-                     <li>Send UDP data with data passed in the <code>data</code> 
-                         member of the <a>UDPMessage</a> object. The destination 
-                         address is the address defined by the 
-                         <a>UDPMesssage</a> object's <code>remoteAddress</code> 
+                         packets to this address and port then throw DOMException
+                         <code>SecurityError</code> and abort these steps.
+                     <li>Send UDP data with data passed in the <code>data</code>
+                         member of the <a>UDPMessage</a> object. The destination
+                         address is the address defined by the
+                         <a>UDPMesssage</a> object's <code>remoteAddress</code>
                          member if present, else the destination address
-                         is defined by the UDPSocket's constructor 
-                         <code>options</code> argument's 
-                         <code>remoteAddress</code> member. The destination 
-                         port is the port defined by the 
-                         <a>UDPMesssage</a> object's <code>remotePort</code> 
+                         is defined by the UDPSocket's constructor
+                         <code>options</code> argument's
+                         <code>remoteAddress</code> member. The destination
+                         port is the port defined by the
+                         <a>UDPMesssage</a> object's <code>remotePort</code>
                          member if present, else the destination port
-                         is defined by the UDPSocket's constructor 
-                         <code>options</code> argument's 
-                         <code>remotePort</code> member.  
+                         is defined by the UDPSocket's constructor
+                         <code>options</code> argument's
+                         <code>remotePort</code> member.
                      <li>If sending succeed resolve <code>writePromise</code>
                          with <code>undefined</code>, else reject
                          <code>writePromise</code> with DOMException
-                         <code>"NetworkError"</code>.     
-                   </ol>                                        
-                                        
-               <li>The constructor's <code>close()</code> and <code>abort()</code> 
-                   functions MUST be omitted as it is not possible to just close 
+                         <code>"NetworkError"</code>.
+                   </ol>
+
+               <li>The constructor's <code>close()</code> and <code>abort()</code>
+                   functions MUST be omitted as it is not possible to just close
                    the writable side of a UDP socket.
-                    
+
                <p class="issue">
                  If the constructor's <code>strategy</code> argument is
-                 omitted the 
-                 <a href= "https://streams.spec.whatwg.org/#default-ws-strategy">Default strategy for Writable Streams</a> 
-                 applies. Currently this means that the WriteableStream 
-                 object goes to "waiting" state after 1 chunk has been 
+                 omitted the
+                 <a href= "https://streams.spec.whatwg.org/#default-ws-strategy">Default strategy for Writable Streams</a>
+                 applies. Currently this means that the WriteableStream
+                 object goes to "waiting" state after 1 chunk has been
                  written to the internal WriteableStream object's output
                  buffer. This means that the <a>webapp</a> should use .ready
-                 to be notified of when the state changes to "writable", 
+                 to be notified of when the state changes to "writable",
                  i.e. the queued chunk has been written to the remote peer
-                 and more data chunks could be written. To be further 
-                 investigated which WritableStreamStrategy that should 
+                 and more data chunks could be written. To be further
+                 investigated which WritableStreamStrategy that should
                  be applied to UDP.
-               </p>                       
+               </p>
              </ul>
-                                       
+
          <li>Return the newly created <code>UDPSocket</code> object ("<code>mySocket</code>")
              to the <a>webapp</a>.
-        </ol>       
-      </p>              
-      
-      <p> The <dfn><code>close</code></dfn> method when invoked MUST run the 
+        </ol>
+      </p>
+
+      <p> The <dfn><code>close</code></dfn> method when invoked MUST run the
          following steps:
         <ol>
-          <li>Call mysocket.readable.cancel(reason). (Reason codes TBD.)  
-          <li>Return <code>closedPromise</code>.       
+          <li>Call mysocket.readable.cancel(reason). (Reason codes TBD.)
+          <li>Return <code>closedPromise</code>.
         </ol>
-      </p>           
-          
-    </section>  
-       
-<!------------------------ Interface TCPSocket ------------------------------>    
+      </p>
+
+    </section>
+
+<!------------------------ Interface TCPSocket ------------------------------>
     <section>
       <h2>Interface <a>TCPSocket</a></h2>
-      <p>The <a>TCPSocket</a> interface defines attributes and methods for TCP 
-         communication</p> 
-      
+      <p>The <a>TCPSocket</a> interface defines attributes and methods for TCP
+         communication</p>
+
       <pre class="example highlight">
-       // 
-       // This example shows a simple TCP echo client. 
-       // The client will send "Hello World" to the server on port 6789 and log 
+       //
+       // This example shows a simple TCP echo client.
+       // The client will send "Hello World" to the server on port 6789 and log
        // what has been received from the server.
-       // 
-       
+       //
+
        //  Request permission to connect to server at address 127.0.0.1 on port
        //  6789
-                      
+
        navigator.tcpPermission.requestPermission({remoteAddress:"127.0.0.1", remotePort:6789}).then(
          () => {
-           // Permission was granted       
-           // Create a new TCP client socket and connect to remote host     
+           // Permission was granted
+           // Create a new TCP client socket and connect to remote host
            var mySocket = new TCPSocket("127.0.0.1", 6789);
-           
+
            // Send data to server
            mySocket.writeable.write("Hello World").then(
                () => {
-                   
+
                    // Data sent sucessfully, wait for response
                    console.log("Data has been sent to server");
-                   mySocket.readable.ready.then(
-                       () => {
-                       
-                           // Data in buffer, read it
-                           console.log("Data received from server:" + mySocket.readable.read());
-           
+                   mySocket.readable.getReader().read().then(
+                       ({ value, done }) => {
+                           if (!done) {
+                               // Response received, log it:
+                               console.log("Data received from server:" + value);
+                           }
+
                            // Close the TCP connection
                            mySocket.close();
                        }
@@ -1275,20 +1269,20 @@ Style guide to contributors:
                },
                e => console.error("Sending error: ", e);
            );
-           
+
            // Signal that we won't be writing any more and can close the write half of the connection.
            mySocket.halfClose();
-    
-           // Log result of TCP connection attempt. 
+
+           // Log result of TCP connection attempt.
            mySocket.opened.then(
              () => {
                console.log("TCP connection established sucessfully");
              },
              e =>console.error("TCP connection setup failed due to error: ", e);
            );
-           
-           // Handle TCP connection closed, either as a result of the webapp 
-           // calling mySocket.close() or the other side closed the TCP  
+
+           // Handle TCP connection closed, either as a result of the webapp
+           // calling mySocket.close() or the other side closed the TCP
            // connection or an error causing the TCP connection to be closed.
            mySocket.closed.then(
              () => {
@@ -1297,436 +1291,433 @@ Style guide to contributors:
              e => console.error("TCP socket closed due to error: ", e);
            );
          },
-         e => console.error("Connection to 127.0.0.1 on port 6789 was denied 
-                            due to error: ", e);    
-       ); 
-      </pre>      
-      
-      <dl title="[Constructor (DOMString remoteAddress, unsigned short remotePort, 
-                 optional TCPOptions options)] 
+         e => console.error("Connection to 127.0.0.1 on port 6789 was denied
+                            due to error: ", e);
+       );
+      </pre>
+
+      <dl title="[Constructor (DOMString remoteAddress, unsigned short remotePort,
+                 optional TCPOptions options)]
                  interface TCPSocket"
-          class="idl">         
-          
+          class="idl">
+
         <dt>readonly attribute DOMString remoteAddress</dt>
-        <dd>The host name or IPv4/6 address of the peer as stated by the 
-            remoteAddress argument in the constructor.</dd>   
-        
+        <dd>The host name or IPv4/6 address of the peer as stated by the
+            remoteAddress argument in the constructor.</dd>
+
         <dt>readonly attribute unsigned short remotePort</dt>
-        <dd>The port of the peer as stated by the remotePort argument in the 
-            constructor. </dd>                              
+        <dd>The port of the peer as stated by the remotePort argument in the
+            constructor. </dd>
 
         <dt>readonly attribute DOMString localAddress</dt>
-        <dd>The IPv4/6 address of the local interface, e.g. wifi or 3G, that the 
+        <dd>The IPv4/6 address of the local interface, e.g. wifi or 3G, that the
             TCPSocket object is bound to. Can be set by the <code>options</code>
-            argument in the constructor. If not set the <a>user agent</a> 
-            binds the socket to an IPv4/6 address based on the routing table and 
-            possibly a preselect default local interface to use for the selected 
-            <code>remoteAddress</code>. </dd>   
-        
+            argument in the constructor. If not set the <a>user agent</a>
+            binds the socket to an IPv4/6 address based on the routing table and
+            possibly a preselect default local interface to use for the selected
+            <code>remoteAddress</code>. </dd>
+
         <dt>readonly attribute unsigned short localPort</dt>
-        <dd>The local port that the TCPSocket object is bound to. Can be set by 
+        <dd>The local port that the TCPSocket object is bound to. Can be set by
             the <code>options</code> argument in the constructor. If not set the
-            <a>user agent</a> binds the socket to an ephemeral local port decided by 
-            the system. </dd>  
-            
+            <a>user agent</a> binds the socket to an ephemeral local port decided by
+            the system. </dd>
+
         <dt>readonly attribute boolean addressReuse</dt>
-        <dd><code>true</code> allows the socket to be bound to a local address/port 
-            pair that already is in use. Can be set by the <code>options</code> 
-            argument in the constructor. Default is <code>true</code>.</dd> 
-            
+        <dd><code>true</code> allows the socket to be bound to a local address/port
+            pair that already is in use. Can be set by the <code>options</code>
+            argument in the constructor. Default is <code>true</code>.</dd>
+
         <dt>readonly attribute boolean noDelay</dt>
-        <dd><code>true</code> if the Nagle algorithm for send coalescing,  
-            [[!NAGLE]], is disabled. Can be set by the 
-            <code>options</code> argument in the constructor. Default is 
-            <code>true</code>.</dd>                                   
-            
+        <dd><code>true</code> if the Nagle algorithm for send coalescing,
+            [[!NAGLE]], is disabled. Can be set by the
+            <code>options</code> argument in the constructor. Default is
+            <code>true</code>.</dd>
+
         <dt>readonly attribute SocketReadyState readyState</dt>
-        <dd>The state of the TCP Socket object. See enum <a>SocketReadyState</a> for 
-            details.</dd>  
-            
+        <dd>The state of the TCP Socket object. See enum <a>SocketReadyState</a> for
+            details.</dd>
+
         <dt> readonly attribute Promise opened</dt>
-        <dd> Detects the result of the TCP connection attempt with the remote 
-             peer. Returns the <code>openedPromise</code> that was created 
-             in the <code>TCPSocket</code> constructor.    
-        </dd>           
-        
+        <dd> Detects the result of the TCP connection attempt with the remote
+             peer. Returns the <code>openedPromise</code> that was created
+             in the <code>TCPSocket</code> constructor.
+        </dd>
+
         <dt> readonly attribute Promise closed</dt>
-        <dd> Detects when the TCP connection has been closed, either cleanly 
-             (initiated either by the server, or by the client <a>webapp</a> 
+        <dd> Detects when the TCP connection has been closed, either cleanly
+             (initiated either by the server, or by the client <a>webapp</a>
              calling <code>close()</code>) or through an error situation.
-             Returns the <code>closedPromise</code> that was created 
-             in the <code>TCPSocket</code> constructor.    
-        </dd>            
-         
+             Returns the <code>closedPromise</code> that was created
+             in the <code>TCPSocket</code> constructor.
+        </dd>
+
         <dt>readonly attribute ReadableStream readable</dt>
-        <dd>The object that represents the TCP socket's source of data, from which 
-            you can read. [[!STREAMS]] </dd>     
-            
+        <dd>The object that represents the TCP socket's source of data, from which
+            you can read. [[!STREAMS]] </dd>
+
         <dt>readonly attribute WriteableStream writeable</dt>
-        <dd>The object that represents the TCP socket's destination for data, 
-            into which you can write. [[!STREAMS]] </dd>               
+        <dd>The object that represents the TCP socket's destination for data,
+            into which you can write. [[!STREAMS]] </dd>
 
         <dt> Promise close()</dt>
-        <dd>        
-          <p>Closes the TCP socket. Returns the <code>closedPromise</code> that 
-             was created in the <code>TCPSocket</code> constructor. </p>        
-        </dd>   
-        
+        <dd>
+          <p>Closes the TCP socket. Returns the <code>closedPromise</code> that
+             was created in the <code>TCPSocket</code> constructor. </p>
+        </dd>
+
         <dt> void halfClose()</dt>
-        <dd>        
-          <p>Half closes the TCP socket.</p>        
-        </dd>                                                                    
-                            
-      </dl>          
-      
-      <p>When the <a>TCPSocket</a> constructor is invoked, the <a>user agent</a> MUST 
-         run the following steps:        
+        <dd>
+          <p>Half closes the TCP socket.</p>
+        </dd>
+
+      </dl>
+
+      <p>When the <a>TCPSocket</a> constructor is invoked, the <a>user agent</a> MUST
+         run the following steps:
         <ol>
          <li>Create a new TCPSocket object ("<code>mySocket</code>").
-         <li>If the <a>webapp</a> does not have permission to create a TCPSocket 
+         <li>If the <a>webapp</a> does not have permission to create a TCPSocket
              object that connects to the <code>remoteAddress</code>/<code>remotePort</code>
-             as stated by the input arguments, then throw DOMException 
+             as stated by the input arguments, then throw DOMException
              <code>"SecurityError"</code> and abort the remaining steps.
          <li>If the <code>remoteAddress</code> argument is not a valid host name
-             or IPv4/6 address and/or the <code>remotePort</code> argument is 
-             not a valid port number then throw DOMException <code>"InvalidAccessError"</code> 
-             and abort the remaining steps, else set the <code>mySocket.remoteAddress</code> 
+             or IPv4/6 address and/or the <code>remotePort</code> argument is
+             not a valid port number then throw DOMException <code>"InvalidAccessError"</code>
+             and abort the remaining steps, else set the <code>mySocket.remoteAddress</code>
              and <code>mySocket.remotePort</code> attributes to the requested values.
-         <li>If the <code>options</code> argument's <code>localAddress</code> 
+         <li>If the <code>options</code> argument's <code>localAddress</code>
              member is present and it is a valid IPv4/6 address for a local
-             interface that can be used to connect to the selected 
-             <code>remoteAddress</code> (according to the routing table) bind the 
-             socket to this local IPv4/6 address and set the <code>mySocket.localAddress</code> 
-             attribute to this addres. Else, if the <code>localAddress</code> 
-             member is present but it is not a valid local IPv4/6 address for a 
-             local interface that can be used to connect to the selected 
-             <code>remoteAddress</code> then throw DOMException 
+             interface that can be used to connect to the selected
+             <code>remoteAddress</code> (according to the routing table) bind the
+             socket to this local IPv4/6 address and set the <code>mySocket.localAddress</code>
+             attribute to this addres. Else, if the <code>localAddress</code>
+             member is present but it is not a valid local IPv4/6 address for a
+             local interface that can be used to connect to the selected
+             <code>remoteAddress</code> then throw DOMException
              <code>"InvalidAccessError"</code> and abort the remaining steps.<br/>
-             Otherwise, if the <code>options</code> argument's <code>localAddress</code> 
-             member is absent, execute the following steps: 
+             Otherwise, if the <code>options</code> argument's <code>localAddress</code>
+             member is absent, execute the following steps:
              <ol>
                <li> Use the routing table to determine the local interface(s) that
-                    can be used to connect to the selected <code>remoteAddress</code>. 
-                    If no local interface can be used to connect to the selected 
-                    <code>remoteAddress</code> then throw DOMException 
-                    <code>"InvalidAccessError"</code> and abort the remaining 
+                    can be used to connect to the selected <code>remoteAddress</code>.
+                    If no local interface can be used to connect to the selected
+                    <code>remoteAddress</code> then throw DOMException
+                    <code>"InvalidAccessError"</code> and abort the remaining
                     steps.
-               <li> If the routing table states that more than one local interface 
+               <li> If the routing table states that more than one local interface
                     can be used to connect to the selected <code>remoteAddress</code>
-                    bind the socket to the IPv4/6 address of the "default" local 
-                    interface to use for the selected <code>remoteAddress</code>. 
-                    The selection of a "default" local interface is out of scope 
+                    bind the socket to the IPv4/6 address of the "default" local
+                    interface to use for the selected <code>remoteAddress</code>.
+                    The selection of a "default" local interface is out of scope
                     for this specification.
-               <li> Set the <code>mySocket.localAddress</code> attribute to the 
-                    local address that the socket is bound to.             
-             </ol>             
-         <li>If the <code>options</code> argument's <code>localPort</code> member 
-             is absent then bind the socket to an ephemeral local port decided 
-             by the system and set the <code>mySocket.localPort</code> attribute 
-             to this port. 
-             Otherwise, bind the socket to the requested local port and set the 
-             <code>mySocket.localPort</code> attribute to the local port that 
-             the socket is bound to.             
-         <li>Set the <code>mySocket.addressReuse</code> attribute to the value 
-             of the <code>options</code> argument's <code>addressReuse</code> 
-             member if it is present or to <code>true</code> if the <code>options</code> 
+               <li> Set the <code>mySocket.localAddress</code> attribute to the
+                    local address that the socket is bound to.
+             </ol>
+         <li>If the <code>options</code> argument's <code>localPort</code> member
+             is absent then bind the socket to an ephemeral local port decided
+             by the system and set the <code>mySocket.localPort</code> attribute
+             to this port.
+             Otherwise, bind the socket to the requested local port and set the
+             <code>mySocket.localPort</code> attribute to the local port that
+             the socket is bound to.
+         <li>Set the <code>mySocket.addressReuse</code> attribute to the value
+             of the <code>options</code> argument's <code>addressReuse</code>
+             member if it is present or to <code>true</code> if the <code>options</code>
              argument's <code>addressReuse</code> member is not present.
-         <li>Set the <code>mySocket.noDelay</code> attribute to the value of 
-             the <code>options</code> argument's <code>noDelay</code> member 
-             if it is present or to <code>true</code> if the <code>options</code> 
-             argument's <code>noDelay</code> member is not present.             
-         <li>Set the <code>mySocket.readyState</code> attribute to "opening".          
-         <li>Create a new promise, "<code>openedPromise</code>", and store 
-             it so it can later be returned by the <code>opened</code> 
-             property.    
-         <li>Create a new promise, "<code>closedPromise</code>", and store 
-             it so it can later be returned by the <code>closed</code> 
-             property and the <code>close</code> method.               
-         
-         <li>Let the <code>mySocket.readable</code> attribute be a new 
-             ReadableStream object, [[!STREAMS]]. The <a>user agent</a> MUST implement 
-             the adaptation layer to [[!STREAMS]] for this new ReadableStream 
-             object through implementation of a number of functions that are 
-             given as input arguments to the constructor and called by the 
-             [[!STREAMS]] implementation. The semantics for these 
+         <li>Set the <code>mySocket.noDelay</code> attribute to the value of
+             the <code>options</code> argument's <code>noDelay</code> member
+             if it is present or to <code>true</code> if the <code>options</code>
+             argument's <code>noDelay</code> member is not present.
+         <li>Set the <code>mySocket.readyState</code> attribute to "opening".
+         <li>Create a new promise, "<code>openedPromise</code>", and store
+             it so it can later be returned by the <code>opened</code>
+             property.
+         <li>Create a new promise, "<code>closedPromise</code>", and store
+             it so it can later be returned by the <code>closed</code>
+             property and the <code>close</code> method.
+
+         <li>Let the <code>mySocket.readable</code> attribute be a new
+             ReadableStream object, [[!STREAMS]]. The <a>user agent</a> MUST implement
+             the adaptation layer to [[!STREAMS]] for this new ReadableStream
+             object through implementation of a number of functions that are
+             given as input arguments to the constructor and called by the
+             [[!STREAMS]] implementation. The semantics for these
              functions are described below:
 
-             <ul> 
-               <li>The constructor's <code>start()</code> function is called 
-                   immediately by the [[!STREAMS]] implementation. 
+             <ul>
+               <li>The constructor's <code>start()</code> function is called
+                   immediately by the [[!STREAMS]] implementation.
                    The <code>start()</code> function MUST run the following steps:
                    <ol>
-                     <li>A TCP connection setup handshake to the requested 
-                         address and port MUST be performed in the background 
+                     <li>A TCP connection setup handshake to the requested
+                         address and port MUST be performed in the background
                          (without blocking scripts). Return <code>openedPromise</code>.
-                     <li>When the TCP connection has been successfully established 
-                         the following steps MUST run:      
+                     <li>When the TCP connection has been successfully established
+                         the following steps MUST run:
                        <ol>
-                         <li>Change the <code>mySocket.readyState</code> attribute's value to 
-                             "open".    
+                         <li>Change the <code>mySocket.readyState</code> attribute's value to
+                             "open".
                          <li>Resolve <code>openedPromise</code> with <code>undefined</code>.
                        </ol>
-                   </ol>                       
-                   The following functions are arguments of the constructor's 
-                   <code>start()</code> function and MUST be called by the 
+                   </ol>
+                   The following functions are arguments of the constructor's
+                   <code>start()</code> function and MUST be called by the
                    <code>start()</code> function implementation according to the
                    following steps:
-                   <ul>                     
-                     <li>The <code>enqueue()</code> argument of <code>start()</code> 
-                         is a function that pushes received data into the 
+                   <ul>
+                     <li>The <code>enqueue()</code> argument of <code>start()</code>
+                         is a function that pushes received data into the
                          internal buffer. <br>
-                         When new TCP data is received the following steps MUST 
+                         When new TCP data is received the following steps MUST
                          run:
-                         <ol>                                     
-                           <li>Create a new read-only <code>ArrayBuffer</code> 
+                         <ol>
+                           <li>Create a new read-only <code>ArrayBuffer</code>
                                object whose contents are the received TCP data.
                            <li>Call <code>enqueue()</code> to push the
-                               <code>ArrayBuffer</code> into the internal 
-                               [[!STREAMS]] receive buffer. 
-                           <li>If the high watermark of the buffer is reached 
-                               <code>enqueue()</code> returns false and the TCP 
-                               flow control MUST be used to stop the data 
-                               transmission from the remote peer.          
-                         </ol>                                                           
-                     <li>The <code>close()</code> argument of <code>start()</code> 
-                         is a function that closes the readable stream.<br> 
+                               <code>ArrayBuffer</code> into the internal
+                               [[!STREAMS]] receive buffer.
+                           <li>If the high watermark of the buffer is reached
+                               <code>enqueue()</code> returns false and the TCP
+                               flow control MUST be used to stop the data
+                               transmission from the remote peer.
+                         </ol>
+                     <li>The <code>close()</code> argument of <code>start()</code>
+                         is a function that closes the readable stream.<br>
                          Upon detection that the TCP connection has been closed
-                         cleanly (initiated either by the server, or by 
-                         the client <a>webapp</a> calling <code>close()</code>) 
-                         through a successful TCP connection closing handshake 
-                         the following steps MUST run:      
-                         <ol>  
-                           <li>Call <code>close()</code>.  
-                           <li>Set the <code>mySocket.readyState</code> attribute's 
-                               value to "closed" and release any 
-                               underlying resources associated with this socket.  
-                           <li>Resolve <code>closedPromise</code> with 
-                               <code>undefined</code>.       
-                         </ol> 
-                      <li>The <code>error()</code> argument of <code>start()</code> 
-                          is a function that handles readable stream errors and 
-                          closes the readble stream.<br> 
-                          Upon detection that the attempt to 
-                          create a new TCP socket and establish a new TCP 
-                          connection (<code>mySocket.readyState</code> is "opening") has 
-                          failed the following steps MUST run:      
-                          <ol>                                                 
-                            <li>Call <code>error()</code> with DOMException 
+                         cleanly (initiated either by the server, or by
+                         the client <a>webapp</a> calling <code>close()</code>)
+                         through a successful TCP connection closing handshake
+                         the following steps MUST run:
+                         <ol>
+                           <li>Call <code>close()</code>.
+                           <li>Set the <code>mySocket.readyState</code> attribute's
+                               value to "closed" and release any
+                               underlying resources associated with this socket.
+                           <li>Resolve <code>closedPromise</code> with
+                               <code>undefined</code>.
+                         </ol>
+                      <li>The <code>error()</code> argument of <code>start()</code>
+                          is a function that handles readable stream errors and
+                          closes the readble stream.<br>
+                          Upon detection that the attempt to
+                          create a new TCP socket and establish a new TCP
+                          connection (<code>mySocket.readyState</code> is "opening") has
+                          failed the following steps MUST run:
+                          <ol>
+                            <li>Call <code>error()</code> with DOMException
                                 <code>"NetworkError"</code>.
-                            <li>Reject <code>openedPromise</code> with DOMException 
-                                <code>"NetworkError"</code>.   
-                            <li>Reject <code>closedPromise</code> with DOMException 
-                                <code>"NetworkError"</code>.             
-                            <li>Change the <code>mySocket.readyState</code> attribute's value 
-                                to "closed" and release any underlying resources 
-                                associated with this socket.                               
-                          </ol> 
-                          Upon detection that the established TCP connection 
-                          (<code>mySocket.readyState</code> is "open") has been lost 
-                          the following steps MUST run:      
-                          <ol>                                                 
-                            <li>Call <code>error()</code> with DOMException 
-                                <code>"NetworkError"</code>. 
-                            <li>Reject <code>closedPromise</code> with DOMException 
-                                <code>"NetworkError"</code>.                                                                  
-                            <li>Change the <code>mySocket.readyState</code> 
-                                attribute's value to "closed" and release any 
-                                underlying resources associated with this 
-                                socket.                               
-                          </ol>   
+                            <li>Reject <code>openedPromise</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Reject <code>closedPromise</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Change the <code>mySocket.readyState</code> attribute's value
+                                to "closed" and release any underlying resources
+                                associated with this socket.
+                          </ol>
+                          Upon detection that the established TCP connection
+                          (<code>mySocket.readyState</code> is "open") has been lost
+                          the following steps MUST run:
+                          <ol>
+                            <li>Call <code>error()</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Reject <code>closedPromise</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Change the <code>mySocket.readyState</code>
+                                attribute's value to "closed" and release any
+                                underlying resources associated with this
+                                socket.
+                          </ol>
                           Upon detection that the TCP connection closing
                           handshake failed (<code>mySocket.readyState</code> is "closing")
-                          has failed the following steps MUST run:      
-                          <ol>                                                 
-                            <li>Call <code>error()</code> with DOMException 
-                                <code>"NetworkError"</code>.  
-                            <li>Reject <code>closedPromise</code> with DOMException 
-                                <code>"NetworkError"</code>.                                      
-                            <li>Change the <code>mySocket.readyState</code> 
-                                attribute's value to "closed" and release any 
-                                underlying resources associated with this socket.                               
-                          </ol>   
-                          When new TCP data has been received and upon 
-                          detction that it is not possible to convert the 
-                          received data to <code>ArrayBuffer</code>, 
+                          has failed the following steps MUST run:
+                          <ol>
+                            <li>Call <code>error()</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Reject <code>closedPromise</code> with DOMException
+                                <code>"NetworkError"</code>.
+                            <li>Change the <code>mySocket.readyState</code>
+                                attribute's value to "closed" and release any
+                                underlying resources associated with this socket.
+                          </ol>
+                          When new TCP data has been received and upon
+                          detction that it is not possible to convert the
+                          received data to <code>ArrayBuffer</code>,
                           [[!TYPED-ARRAYS]], the following steps MUST run:
                           <ol>
-                            <li>Call <code>error()</code> with <code>TypeError</code>. 
-                            <li>Reject <code>closedPromise</code> with 
-                                <code>TypeError</code>.                                                                  
-                            <li>Change the <code>mySocket.readyState</code> 
-                                attribute's value to "closed" and release any 
-                                underlying resources associated with this socket. 
-                          </ol>     
-                   </ul>                  
-                 <li>The constructor's <code>pull()</code> function is called 
-                     by the [[!STREAMS]] implementation if the internal buffer 
-                     has been emptied, but the stream's consumer still wants more 
-                     data. 
+                            <li>Call <code>error()</code> with <code>TypeError</code>.
+                            <li>Reject <code>closedPromise</code> with
+                                <code>TypeError</code>.
+                            <li>Change the <code>mySocket.readyState</code>
+                                attribute's value to "closed" and release any
+                                underlying resources associated with this socket.
+                          </ol>
+                   </ul>
+                 <li>The constructor's <code>pull()</code> function is called
+                     by the [[!STREAMS]] implementation if the internal buffer
+                     has been emptied, but the stream's consumer still wants more
+                     data.
                      The <code>pull()</code> function MUST run the following steps:
                      <ol>
-                       <li>The function MUST resume receiving TCP data through the 
-                           TCP flow control mechanism.  
-                     </ol>                       
-                 <li>The constructor's <code>cancel()</code> function input 
-                     argument is called by the [[!STREAMS]] implementation when 
+                       <li>The function MUST resume receiving TCP data through the
+                           TCP flow control mechanism.
+                     </ol>
+                 <li>The constructor's <code>cancel()</code> function input
+                     argument is called by the [[!STREAMS]] implementation when
                      the ReadbleStream should be canceled. For TCP this means that
                      the TCP connection should be terminated.
-                     The <code>cancel()</code> function MUST run the following steps:  
+                     The <code>cancel()</code> function MUST run the following steps:
                      <ol>
-                       <li>If <code>mySocket.readyState</code> is "closing" or "closed" then 
-                           do nothing and abort the remaning steps.    
-                       <li>If <code>mySocket.readyState</code> is "opening" then fail the 
+                       <li>If <code>mySocket.readyState</code> is "closing" or "closed" then
+                           do nothing and abort the remaning steps.
+                       <li>If <code>mySocket.readyState</code> is "opening" then fail the
                            connection attempt, reject <code>openedPromise</code> and
-                           <code>closedPromise</code> with DOMException 
+                           <code>closedPromise</code> with DOMException
                            <code>AbortError</code> and set the <code>mySocket.readyState</code>
-                           attribute to "closing".                     
-                       <li>If <code>mySocket.readyState</code> is "open" then the 
+                           attribute to "closing".
+                       <li>If <code>mySocket.readyState</code> is "open" then the
                            following steps MUST run:
-                           <ol>  
-                             <li>Call <code>mySocket.writeable.close()</code> to 
-                                 assure that any buffered send data is sent 
-                                 before closing the socket.  
-                             <li>Set the <code>mySocket.readyState</code> 
-                                 attribute's value to "closing".  
-                             <li>Initiate TCP closing handshake.       
-                           </ol>                              
-                              
-                     </ol>  
-                   
+                           <ol>
+                             <li>Call <code>mySocket.writeable.close()</code> to
+                                 assure that any buffered send data is sent
+                                 before closing the socket.
+                             <li>Set the <code>mySocket.readyState</code>
+                                 attribute's value to "closing".
+                             <li>Initiate TCP closing handshake.
+                           </ol>
+
+                     </ol>
+
                  <p class="issue">
                    If the constructor's <code>strategy</code> argument is
-                   omitted the 
-                   <a href= "https://streams.spec.whatwg.org/#default-rs-strategy">Default strategy for Readable Streams</a> 
-                   applies. Currently this means that the ReadableStream 
-                   object goes to "readable" state after 1 chunk has been 
-                   enqueued to the internal ReadableStream object's input
-                   buffer. A <a>webapp</a> should use .ready to be notified 
-                   when the state changes to "readable". To be further 
-                   investigated which ReadableStreamStrategy that should 
+                   omitted the default backpressure behavior of readable streams
+                   applies. Currently this means that the ReadableStream object
+                   begins applying backpressure after 1 chunk has been enqueued
+                   to the internal ReadableStream object's input buffer. To be
+                   further investigated which readable stream strategy that should
                    be applied to TCP.
-                 </p>                                         
-             </ul>                   
-                    
-         <li>Let the <code>mySocket.writeable</code> attribute be a new 
-             WritableStream object, [[!STREAMS]]. The <a>user agent</a> MUST implement 
-             the adaptation layer to [[!STREAMS]] for this new WritableStream 
-             object through implementation of a number of functions that are 
-             given as input arguments to the constructor and called by the 
-             [[!STREAMS]] implementation. The semantics for these 
+                 </p>
+             </ul>
+
+         <li>Let the <code>mySocket.writeable</code> attribute be a new
+             WritableStream object, [[!STREAMS]]. The <a>user agent</a> MUST implement
+             the adaptation layer to [[!STREAMS]] for this new WritableStream
+             object through implementation of a number of functions that are
+             given as input arguments to the constructor and called by the
+             [[!STREAMS]] implementation. The semantics for these
              functions are described below:
-                          
-             <ul>                    
+
+             <ul>
                <li>The constructor's <code>start()</code> function MUST run the
                    following steps:
                    <ol>
                      <li>Create a new promise, "<code>writableStartPromise</code>".
                      <li>If the attempt to create a new TCP socket and establish
                          a new TCP connection (see the description of the semantics
-                         for the <code>mySocket.readable</code> attribute 
+                         for the <code>mySocket.readable</code> attribute
                          constructor's <code>start()</code> function ) succeded
                          resolve <code>writableStartPromise</code>
                          with <code>undefined</code>, else reject
                          <code>writableStartPromise</code> with DOMException
-                         <code>"NetworkError"</code>.   
-                   </ol>                                
-               <li>The constructor's <code>write(chunk)</code> function is 
+                         <code>"NetworkError"</code>.
+                   </ol>
+               <li>The constructor's <code>write(chunk)</code> function is
                    called by the [[!STREAMS]] implementation to write data to
                    the remote peer on the TCP connection.
                    The <code>write()</code> function MUST run the following steps:
                    <ol>
                      <li>Create a new promise, "<code>writePromise</code>"
                      <li>Send TCP data with data passed in the <code>chunk</code>
-                         parameter to the address and port of the recipient as 
-                         stated by the TCPSocket object constructor's 
-                         <code>remoteAddress</code> and <code>remotePort</code> 
-                         fields. The data in the <code>chunk</code> parameter 
-                         can be of any type.  
+                         parameter to the address and port of the recipient as
+                         stated by the TCPSocket object constructor's
+                         <code>remoteAddress</code> and <code>remotePort</code>
+                         fields. The data in the <code>chunk</code> parameter
+                         can be of any type.
                      <li>If sending succeed resolve <code>writePromise</code>
                          with <code>undefined</code>, else reject
                          <code>writePromise</code> with DOMException
-                         <code>"NetworkError"</code>.     
-                   </ol>                                   
-               <li>The constructor's <code>close()</code> function is called 
-                   by the [[!STREAMS]] implementation to close the writable 
-                   side of the connection, that is a TCP "half close" is 
-                   performed. The <code>close()</code> function MUST run the 
+                         <code>"NetworkError"</code>.
+                   </ol>
+               <li>The constructor's <code>close()</code> function is called
+                   by the [[!STREAMS]] implementation to close the writable
+                   side of the connection, that is a TCP "half close" is
+                   performed. The <code>close()</code> function MUST run the
                    following steps:
                     <ol>
-                     <li>If <code>mySocket.readyState</code> is "closing" or "closed" then 
+                     <li>If <code>mySocket.readyState</code> is "closing" or "closed" then
                          do nothing.
-                     <li>If <code>mySocket.readyState</code> is "opening" then complete 
-                         the connection attempt. If succesful send FIN and set the 
+                     <li>If <code>mySocket.readyState</code> is "opening" then complete
+                         the connection attempt. If succesful send FIN and set the
                          <code>mySocket.readyState</code> attribute to "halfclosed".
-                     <li>If <code>mySocket.readyState</code> is "open" then send FIN and 
-                         set the <code>mySocket.readyState</code> attribute to "halfclosed".                     
+                     <li>If <code>mySocket.readyState</code> is "open" then send FIN and
+                         set the <code>mySocket.readyState</code> attribute to "halfclosed".
                    </ol>
                    Note that the Streams implementation will call <code>close()</code>
                    after all queued-up writes successfully completed.
-               <li>The constructor's <code>abort()</code> function is called 
-                   by the [[!STREAMS]] implementation to abort the writable 
+               <li>The constructor's <code>abort()</code> function is called
+                   by the [[!STREAMS]] implementation to abort the writable
                    side of the connection. This function MUST run the same steps
-                   as <code>close()</code> but note that the Streams 
-                   implementation will throw away any pending queued up chunks.    
-                   
+                   as <code>close()</code> but note that the Streams
+                   implementation will throw away any pending queued up chunks.
+
                    <p class="issue">
                      If the constructor's <code>strategy</code> argument is
-                     omitted the 
-                     <a href= "https://streams.spec.whatwg.org/#default-ws-strategy">Default strategy for Writable Streams</a> 
-                     applies. Currently this means that the WriteableStream 
-                     object goes to "waiting" state after 1 chunk has been 
+                     omitted the
+                     <a href= "https://streams.spec.whatwg.org/#default-ws-strategy">Default strategy for Writable Streams</a>
+                     applies. Currently this means that the WriteableStream
+                     object goes to "waiting" state after 1 chunk has been
                      written to the internal WriteableStream object's output
-                     buffer. This means that the <a>webapp</a> should use .ready 
-                     to be notified of when the state changes to "writable", 
+                     buffer. This means that the <a>webapp</a> should use .ready
+                     to be notified of when the state changes to "writable",
                      i.e. the queued chunk has been written to the remote peer
-                     and more data chunks could be written. To be further 
-                     investigated which WritableStreamStrategy that should 
+                     and more data chunks could be written. To be further
+                     investigated which WritableStreamStrategy that should
                      be applied to TCP.
-                   </p>   
-                                  
-             </ul>                                         
-                                  
-         <li>Return the newly created <a>TCPSocket</a> object ("<code>mySocket</code>") 
+                   </p>
+
+             </ul>
+
+         <li>Return the newly created <a>TCPSocket</a> object ("<code>mySocket</code>")
              to the <a>webapp</a>.
         </ol>
-      </p>                               
-    
-      <p> The <dfn><code>close()</code></dfn> method when invoked MUST run the 
+      </p>
+
+      <p> The <dfn><code>close()</code></dfn> method when invoked MUST run the
           following steps:
         <ol>
-          <li>Call <code>mysocket.readable.cancel(reason)</code>. (Reason codes TBD.)  
+          <li>Call <code>mysocket.readable.cancel(reason)</code>. (Reason codes TBD.)
           <li>Return <code>closedPromise</code>.
         </ol>
-      </p>   
-      
-      <p> The <dfn><code>halfClose()</code></dfn> method when invoked MUST run the 
+      </p>
+
+      <p> The <dfn><code>halfClose()</code></dfn> method when invoked MUST run the
           following steps:
         <ol>
-         <li>Call <code>mysocket.writeable.close()</code>.            
+         <li>Call <code>mysocket.writeable.close()</code>.
         </ol>
-      </p>                     
-      
+      </p>
 
-    </section>             
-    
-<!------------------------ Interface TCPServerSocket ------------------------------>    
+
+    </section>
+
+<!------------------------ Interface TCPServerSocket ------------------------------>
     <section>
       <h2>Interface <a>TCPServerSocket</a></h2>
-      <p>The <a>TCPServerSocket</a> interface supports TCP server sockets that 
-         listens to connection attempts from TCP clients</p> 
-           
+      <p>The <a>TCPServerSocket</a> interface supports TCP server sockets that
+         listens to connection attempts from TCP clients</p>
+
       <pre class="example highlight">
-      // 
-      // This example shows a simple TCP echo server. 
-      // The server will listen on port 6789 and respond back with whatever 
+      //
+      // This example shows a simple TCP echo server.
+      // The server will listen on port 6789 and respond back with whatever
       // has been sent to the server.
-      //    
-      
-       //  Request permission to listen on port 6789                       
+      //
+
+       //  Request permission to listen on port 6789
        navigator.tcpServerPermission.requestPermission({"localPort":6789}).then(
          () => {
-           // Permission was granted     
-                    
+           // Permission was granted
+
            //  Create a new server socket that listens on port 6789
            var myServerSocket = new TCPServerSocket({"localPort": 6789});
 
@@ -1736,54 +1727,56 @@ Style guide to contributors:
              myServerSocket.listen().then(
                  connectedSocket => {
                  // A connection has been accepted
-                 
-                   console.log ("Connection accepted from address: " + 
-                                 connectedSocket.remoteAddress + " port: " + 
-                                 connectedSocket.remotePort);         
+
+                   console.log ("Connection accepted from address: " +
+                                 connectedSocket.remoteAddress + " port: " +
+                                 connectedSocket.remotePort);
+
+                   var reader = connectedSocket.readable.getReader();
+
                    // Wait for data
-                   waitForData ();
-                   function waitForData () {  
-                     connectedSocket.readable.ready.then(
-                       () => {                   
-                           // Data in buffer, read it
-                           var receivedData = connectedSocket.readable.read();
-                           console.log ("Received: " + receivedData);
-                           
-                           // Send data back
-                           connected.writeable.write(receivedData).then(
-                             () => {                         
-                               console.log ("Sending data succeeded");                      
-                             },
-                             e => console.error("Failed to send: ", e);     
-                           },
-                           // Continue to wait for data
-                           waitForData ();
-                       } 
+                   waitForData();
+                   function waitForData () {
+                     reader.read().then(
+                       ({ value, done }) => {
+                         if (done) return;
+
+                         // Data in buffer, read it
+                         console.log("Received: " + value);
+
+                         // Send data back
+                         connected.writeable.write(value).then(
+                           () => console.log("Sending data succeeded"),
+                           e => console.error("Failed to send: ", e);
+                         });
+                         // Continue to wait for data
+                         waitForData ();
+                       }
                      );
-                   
+
                    }
-                        
+
                    // Continue to listen for new connections
-                   listenForConnections();    
+                   listenForConnections();
              },
                  e => {
                    console.error("A client connection attempt failed: ", e);
-    
+
                    // Continue to listen for new connections
-                   listenForConnections();                  
-                 }  
-      
+                   listenForConnections();
+                 }
+
              );
            }
-    
-           // Log result of TCP server socket creation attempt. 
+
+           // Log result of TCP server socket creation attempt.
            myServerSocket.opened.then(
              () => {
                console.log("TCP server socket created sucessfully");
              },
              e =>console.error("TCP server socket creation failed due to error: ", e);
            );
-           
+
            // Handle TCP server closed, either as a result of the webapp
            // calling myServerSocket.close() or due to an error.
            myServerSocket.closed.then(
@@ -1792,543 +1785,543 @@ Style guide to contributors:
              },
              e => console.error("TCP server socket closed due to error: ", e);
            );
-           
-         },
-         e => console.error("TCP Server Socket on local port 6789 was denied 
-                            due to error: ", e);    
-       );            
 
-      </pre>        
-      
-      <dl title="[Constructor (optional TCPServerOptions options)] 
+         },
+         e => console.error("TCP Server Socket on local port 6789 was denied
+                            due to error: ", e);
+       );
+
+      </pre>
+
+      <dl title="[Constructor (optional TCPServerOptions options)]
                  interface TCPServerSocket"
-          class="idl">                
-        
+          class="idl">
+
         <dt>readonly attribute DOMString localAddress</dt>
-        <dd>The IPv4/6 address of the interface, e.g. wifi or 3G, that the 
-            TCPServer Socket object is bound to. Can be set by the 
-            <code>options</code> argument in the constructor. If not set the 
-            the server will accept connections directed to any IPv4 address 
-            and this atribute is set to <code>null</code>. 
-        </dd>   
-        
+        <dd>The IPv4/6 address of the interface, e.g. wifi or 3G, that the
+            TCPServer Socket object is bound to. Can be set by the
+            <code>options</code> argument in the constructor. If not set the
+            the server will accept connections directed to any IPv4 address
+            and this atribute is set to <code>null</code>.
+        </dd>
+
         <dt>readonly attribute unsigned short localPort</dt>
-        <dd>The local port that the TCPServerSocket object is bound to. Can be 
-            set by the <code>options</code> argument in the constructor. If not 
-            set the <a>user agent</a> binds the socket to an ephemeral local port 
-            decided by the system and sets this atribute to <code>null</code>. 
-        </dd>       
-        
+        <dd>The local port that the TCPServerSocket object is bound to. Can be
+            set by the <code>options</code> argument in the constructor. If not
+            set the <a>user agent</a> binds the socket to an ephemeral local port
+            decided by the system and sets this atribute to <code>null</code>.
+        </dd>
+
         <dt>readonly attribute boolean addressReuse</dt>
-        <dd><code>true</code> allows the socket to be bound to a local 
-            address/port pair that already is in use. Can be set by the 
-            <code>options</code> argument in the constructor. Default is 
-            <code>true</code>.</dd>                    
-        
+        <dd><code>true</code> allows the socket to be bound to a local
+            address/port pair that already is in use. Can be set by the
+            <code>options</code> argument in the constructor. Default is
+            <code>true</code>.</dd>
+
         <dt>readonly attribute SocketReadyState readyState</dt>
-        <dd>The state of the TCP server object. A TCP server socket object can 
-            be in "open", "opening" or "closed" states. See enum <a>SocketReadyState</a> 
-            for details. </dd>       
-            
+        <dd>The state of the TCP server object. A TCP server socket object can
+            be in "open", "opening" or "closed" states. See enum <a>SocketReadyState</a>
+            for details. </dd>
+
         <dt> readonly attribute Promise opened</dt>
-        <dd> Detects the result of the TCP server socket opening process when 
-             the socket is ready to receive connection attempts from clients. 
-             Returns the <code>openedPromise</code> that was created in the 
-             <code>TCPServerSocket</code> constructor.    
-        </dd>   
-        
+        <dd> Detects the result of the TCP server socket opening process when
+             the socket is ready to receive connection attempts from clients.
+             Returns the <code>openedPromise</code> that was created in the
+             <code>TCPServerSocket</code> constructor.
+        </dd>
+
         <dt> readonly attribute Promise closed</dt>
-        <dd> Detects when the TCP server socket been closed, either cleanly 
-             by the <a>webapp</a> calling <code>close()</code>) or through 
-             an error situation. Returns the <code>closedPromise</code> that 
-             was created in the <code>TCPSocket</code> constructor.    
-        </dd>                                              
-            
+        <dd> Detects when the TCP server socket been closed, either cleanly
+             by the <a>webapp</a> calling <code>close()</code>) or through
+             an error situation. Returns the <code>closedPromise</code> that
+             was created in the <code>TCPSocket</code> constructor.
+        </dd>
+
         <dt> Promise listen()</dt>
-        <dd>        
-          <p>Listens for incoming connection attempts on the specified port and 
-             address. Returns the <code>connectionPromise</code>, which is for 
-             a succeful connection resolved with the <code>TCPSocket</code> 
+        <dd>
+          <p>Listens for incoming connection attempts on the specified port and
+             address. Returns the <code>connectionPromise</code>, which is for
+             a succeful connection resolved with the <code>TCPSocket</code>
              object for the accepted TCP connection and rejected with
-             DOMException <code>"NetworkError"</code> if there is an error on 
-             an incoming connection attempt.</p>        
-        </dd> 
+             DOMException <code>"NetworkError"</code> if there is an error on
+             an incoming connection attempt.</p>
+        </dd>
 
         <dt> Promise close()</dt>
-        <dd>        
-          <p>Closes the TCP server socket. If <code>listen()</code> has been 
-             called the listening for incoming connections is stopped but existing 
-             TCP connections are kept open. Returns the 
-             <code>closedPromise</code> that was created in the 
-             <code>TCPServerSocket</code> constructor. </p>        
-        </dd>                                                                      
-                            
-      </dl>   
-      
-      <p>When the <a>TCPServerSocket</a> constructor is invoked, the <a>user agent</a> 
-         MUST run the following steps:        
+        <dd>
+          <p>Closes the TCP server socket. If <code>listen()</code> has been
+             called the listening for incoming connections is stopped but existing
+             TCP connections are kept open. Returns the
+             <code>closedPromise</code> that was created in the
+             <code>TCPServerSocket</code> constructor. </p>
+        </dd>
+
+      </dl>
+
+      <p>When the <a>TCPServerSocket</a> constructor is invoked, the <a>user agent</a>
+         MUST run the following steps:
         <ol>
          <li>Create a new <a>TCPServerSocket</a> object ("<code>myServerSocket</code>").
-         <li>If the <a>webapp</a> does not have permission to create a 
+         <li>If the <a>webapp</a> does not have permission to create a
              <a>TCPServerSocket</a> object according to the <code>options</code>
              argument then throw DOMException <code>"SecurityError"</code> and
-             abort the remaining steps.           
-         <li>If the <code>options</code> argument's <code>localAddress</code> 
-             member is absent the server will accept connections directed to 
+             abort the remaining steps.
+         <li>If the <code>options</code> argument's <code>localAddress</code>
+             member is absent the server will accept connections directed to
              any IPv4 address and the <code>localAddress</code> attribute is
-             set to <code>null</code>. 
+             set to <code>null</code>.
              Otherwise, if the requested local address is a valid IPv4/6 address
              for a local interface on the device bind the server socket to this
-             local IPv4/6 address and set the <code>localAddress</code> 
-             attribute to this address. Else, if the <code>localAddress</code> 
+             local IPv4/6 address and set the <code>localAddress</code>
+             attribute to this address. Else, if the <code>localAddress</code>
              member is present but it is not a valid local IPv4/6 address for a
-             local interface on the device, throw DOMException <code>InvalidAccessError</code> 
-             and abort the remaining steps. 
+             local interface on the device, throw DOMException <code>InvalidAccessError</code>
+             and abort the remaining steps.
          <li>If the <code>options</code> argument's <code>localPort</code> member
-             is absent then bind the socket to an ephemeral local port decided 
-             by the system and set the <code>localPort</code> attribute to 
-             <code>null</code>. 
-             Otherwise, bind the socket to the requested local port and 
-             set the <code>localPort</code> attribute to the local port that the 
-             socket is bound to.             
+             is absent then bind the socket to an ephemeral local port decided
+             by the system and set the <code>localPort</code> attribute to
+             <code>null</code>.
+             Otherwise, bind the socket to the requested local port and
+             set the <code>localPort</code> attribute to the local port that the
+             socket is bound to.
          <li>Set the <code>addressReuse</code> attribute to the value of the
-             <code>options</code> argument's <code>addressReuse</code> member 
-             if it is present or to <code>true</code> if the <code>options</code> 
-             argument's <code>addressReuse</code> member is not present.                                             
-         <li>Set the <code>myServerSocket.readyState</code> attribute to "opening".  
-         <li>Create a new promise, "<code>openedPromise</code>", and store 
-             it so it can later be returned by the <code>opened</code> 
-             property.    
-         <li>Create a new promise, "<code>closedPromise</code>", and store 
-             it so it can later be returned by the <code>closed</code> 
-             property and the <code>close</code> method.               
-         <li>Return the newly created <a>TCPServerSocket</a> object to the 
+             <code>options</code> argument's <code>addressReuse</code> member
+             if it is present or to <code>true</code> if the <code>options</code>
+             argument's <code>addressReuse</code> member is not present.
+         <li>Set the <code>myServerSocket.readyState</code> attribute to "opening".
+         <li>Create a new promise, "<code>openedPromise</code>", and store
+             it so it can later be returned by the <code>opened</code>
+             property.
+         <li>Create a new promise, "<code>closedPromise</code>", and store
+             it so it can later be returned by the <code>closed</code>
+             property and the <code>close</code> method.
+         <li>Return the newly created <a>TCPServerSocket</a> object to the
              <a>webapp</a>.
         </ol>
-      </p>      
-      
-      <p> The <dfn><code>close</code></dfn> method when invoked MUST run the 
+      </p>
+
+      <p> The <dfn><code>close</code></dfn> method when invoked MUST run the
           following steps:
         <ol>
-         <li>If a TCP connection setup is in progress the connection setup is 
+         <li>If a TCP connection setup is in progress the connection setup is
              finalized according to the descriptions below.
-         <li>Stop listening to further connection attempts from clients.  
+         <li>Stop listening to further connection attempts from clients.
          <li>Set the <code>myServerSocket.readyState</code> attribute to "closed".
-         <li>Resolve <code>closedPromise</code> with 
-             <code>undefined</code>.       
+         <li>Resolve <code>closedPromise</code> with
+             <code>undefined</code>.
         </ol>
-      </p>         
-      
-      <p> The <dfn><code>listen</code></dfn> method when invoked MUST run the 
+      </p>
+
+      <p> The <dfn><code>listen</code></dfn> method when invoked MUST run the
           following steps:
         <ol>
          <li>If <code>myServerSocket.readyState</code> attribute is"closed" then
-             throw DOMException <code>"InvalidStateError"</code> and abort the 
+             throw DOMException <code>"InvalidStateError"</code> and abort the
              remaining steps.
          <li>Create a new promise, "<code>connectionPromise</code>".
-         <li>Start listening for connections on the specified local port 
-             and address. Return <code>connectionPromise</code>.          
+         <li>Start listening for connections on the specified local port
+             and address. Return <code>connectionPromise</code>.
         </ol>
-      </p>                    
-      
-      <p>When a new TCP server socket has successfully been created the 
+      </p>
+
+      <p>When a new TCP server socket has successfully been created the
          <a>user agent</a> MUST run the following steps:
-      
+
         <ol>
-          <li>Change the <code>myServerSocket.readyState</code> attribute's value to "open".  
-          <li>Resolve <code>openedPromise</code> with <code>undefined</code>.          
+          <li>Change the <code>myServerSocket.readyState</code> attribute's value to "open".
+          <li>Resolve <code>openedPromise</code> with <code>undefined</code>.
         </ol>
-      </p>       
-      
-      <p>When the attempt to create a new TCP server socket 
-         (<code>myServerSocket.readyState</code> is "opening") has failed the 
+      </p>
+
+      <p>When the attempt to create a new TCP server socket
+         (<code>myServerSocket.readyState</code> is "opening") has failed the
          <a>user agent</a> MUST run the following steps:
-      
+
         <ol>
-          <li>Change the <code>myServerSocket.readyState</code> attribute's value to 
-              "closed".  
-          <li>Reject <code>openedPromise</code> with DOMException 
-              <code>"NetworkError"</code>.   
-          <li>Reject <code>closedPromise</code> with DOMException 
-              <code>"NetworkError"</code>.                
-        </ol>              
-      </p>    
-      
-      <p>When there is an error on an established TCP server socket 
+          <li>Change the <code>myServerSocket.readyState</code> attribute's value to
+              "closed".
+          <li>Reject <code>openedPromise</code> with DOMException
+              <code>"NetworkError"</code>.
+          <li>Reject <code>closedPromise</code> with DOMException
+              <code>"NetworkError"</code>.
+        </ol>
+      </p>
+
+      <p>When there is an error on an established TCP server socket
          (<code>myServerSocket.readyState</code> is "open"), e.g. loss of network
          contact, the <a>user agent</a> MUST run the following steps:
-      
+
         <ol>
-          <li>Change the <code>myServerSocket.readyState</code> attribute's value to 
-              "closed".  
-          <li>Reject <code>closedPromise</code> with DOMException 
-              <code>"NetworkError"</code>.   
-        </ol>              
-      </p>     
-      
-      <p>Upon a new successful connection to the TCP server socket the 
+          <li>Change the <code>myServerSocket.readyState</code> attribute's value to
+              "closed".
+          <li>Reject <code>closedPromise</code> with DOMException
+              <code>"NetworkError"</code>.
+        </ol>
+      </p>
+
+      <p>Upon a new successful connection to the TCP server socket the
          <a>user agent</a> MUST run the following steps:
-      
+
         <ol>
           <li>Let <var>socket</var> be a new instance of <a>TCPSocket</a>.
-          <li>Set the <code>remoteAddress</code> attribute of <var>socket</var> 
-              to the IPv4/6 address of the peer.    
-          <li>Set the <code>remotePort</code> attribute of <var>socket</var> 
-              to the source port of the of the peer. 
-          <li>Set the <code>localAddress</code> attribute of <var>socket</var> 
-              to the used local IPv4/6 address.    
-          <li>Set the <code>localPort</code> attribute of <var>socket</var> to 
-              the used local source port.   
-          <li>Set the <code>readyState</code> attribute of <var>socket</var> 
-              to "open".    
-          <li>Set the <code>bufferedAmount</code> attribute of <var>socket</var> 
-              to 0.                 
+          <li>Set the <code>remoteAddress</code> attribute of <var>socket</var>
+              to the IPv4/6 address of the peer.
+          <li>Set the <code>remotePort</code> attribute of <var>socket</var>
+              to the source port of the of the peer.
+          <li>Set the <code>localAddress</code> attribute of <var>socket</var>
+              to the used local IPv4/6 address.
+          <li>Set the <code>localPort</code> attribute of <var>socket</var> to
+              the used local source port.
+          <li>Set the <code>readyState</code> attribute of <var>socket</var>
+              to "open".
+          <li>Set the <code>bufferedAmount</code> attribute of <var>socket</var>
+              to 0.
           <li>Resolve <code>connectionPromise</code> with <var>socket</var> as
-              argument.                                                                   
+              argument.
         </ol>
-      </p>                                
-      
-      <p>Upon a new connection attempt to the TCP server socket that can not be 
-         served, e.g. due to max number of open connections, the <a>user agent</a> 
-         MUST run the following steps:
-      
-        <ol>
-          <li>Reject <code>connectionPromise</code> with DOMException 
-              <code>"NetworkError"</code>.   
-        </ol>
-      </p>        
+      </p>
 
-    </section>           
-    
-<!------------------------ Dictionary UDPMessage ------------------------------>          
+      <p>Upon a new connection attempt to the TCP server socket that can not be
+         served, e.g. due to max number of open connections, the <a>user agent</a>
+         MUST run the following steps:
+
+        <ol>
+          <li>Reject <code>connectionPromise</code> with DOMException
+              <code>"NetworkError"</code>.
+        </ol>
+      </p>
+
+    </section>
+
+<!------------------------ Dictionary UDPMessage ------------------------------>
     <section>
       <h2>Dictionary <a>UDPMessage</a></h2>
       <p>The <a>UDPMessage</a> dictionary represents UDP data including
-         address and port of the remote peer. The field data is mandatory 
-         but remoteAddress and remotePort are optional.</p> 
+         address and port of the remote peer. The field data is mandatory
+         but remoteAddress and remotePort are optional.</p>
       <dl title="dictionary UDPMessage"
-          class="idl">   
+          class="idl">
         <dt>ArrayBuffer data</dt>
-        <dd>Received UDP data or UDP data to send.</dd>        
+        <dd>Received UDP data or UDP data to send.</dd>
         <dt>DOMString remoteAddress</dt>
         <dd>The address of the remote machine.</dd>
         <dt>unsigned short remotePort</dt>
-        <dd>The port of the remote machine.</dd>         
-      </dl>       
-      
-    </section>    
-            
-<!------------------------ Dictionary UDPOptions ------------------------------>   
+        <dd>The port of the remote machine.</dd>
+      </dl>
+
+    </section>
+
+<!------------------------ Dictionary UDPOptions ------------------------------>
     <section>
       <h2>Dictionary <a>UDPOptions</a></h2>
       <p>
-        States the options for the UDPSocket. An instance of this dictionary can 
-        optionally be used in the constructor of the <a>UDPSocket</a> object, where 
+        States the options for the UDPSocket. An instance of this dictionary can
+        optionally be used in the constructor of the <a>UDPSocket</a> object, where
         all fields are optional.
-      </p>      
+      </p>
       <dl title="dictionary UDPOptions"
-          class="idl">          
-          
+          class="idl">
+
         <dt>DOMString localAddress</dt>
-        <dd>The IPv4/6 address of the local interface, e.g. wifi or 3G, that the 
-            UDPSocket object is bound to. If the field is omitted, the <a>user agent</a> 
-            binds the socket to an IPv4/6 address based on the routing table and 
-            possibly a preselect default local interface to use for the selected 
-            <code>remoteAddress</code> if this member is present. Else the 
-            UDPSocket is unbound to a local interface. </dd>   
-        
+        <dd>The IPv4/6 address of the local interface, e.g. wifi or 3G, that the
+            UDPSocket object is bound to. If the field is omitted, the <a>user agent</a>
+            binds the socket to an IPv4/6 address based on the routing table and
+            possibly a preselect default local interface to use for the selected
+            <code>remoteAddress</code> if this member is present. Else the
+            UDPSocket is unbound to a local interface. </dd>
+
         <dt>unsigned short localPort</dt>
-        <dd>The local port that the UDPSocket object is bound to. If the the field 
-            is omitted, the <a>user agent</a> binds the socket to a an ephemeral local 
-            port decided by the system.</dd>             
+        <dd>The local port that the UDPSocket object is bound to. If the the field
+            is omitted, the <a>user agent</a> binds the socket to a an ephemeral local
+            port decided by the system.</dd>
 
         <dt>DOMString remoteAddress</dt>
-        <dd>When present the default remote host name or IPv4/6 address 
-            that is used for subsequent send() calls.</dd>   
-        
+        <dd>When present the default remote host name or IPv4/6 address
+            that is used for subsequent send() calls.</dd>
+
         <dt>unsigned short remotePort</dt>
-        <dd>When present the default remote port that is used for subsequent 
-            send() calls.</dd>   
-                          
+        <dd>When present the default remote port that is used for subsequent
+            send() calls.</dd>
+
         <dt>boolean addressReuse</dt>
-        <dd><code>true</code> allows the socket to be bound to a local address/port pair that 
+        <dd><code>true</code> allows the socket to be bound to a local address/port pair that
             already is in use. Default is <code>true</code>.</dd>
-            
+
         <dt>boolean loopback</dt>
-        <dd>Only applicable for multicast. <code>true</code> means that sent 
-            multicast data is looped back to the sender. 
-            Default is <code>false</code>.</dd>     
-   
-      </dl>   
-                  
-    </section>        
-    
-<!------------------------ Dictionary TCPOptions ------------------------------>   
+        <dd>Only applicable for multicast. <code>true</code> means that sent
+            multicast data is looped back to the sender.
+            Default is <code>false</code>.</dd>
+
+      </dl>
+
+    </section>
+
+<!------------------------ Dictionary TCPOptions ------------------------------>
     <section>
       <h2>Dictionary <a>TCPOptions</a></h2>
       <p>
-        States the options for the TCPSocket. An instance of this dictionary can 
-        optionally be used in the constructor of the <a>TCPSocket</a> object, 
-        where all fields are optional.   
-      </p>      
+        States the options for the TCPSocket. An instance of this dictionary can
+        optionally be used in the constructor of the <a>TCPSocket</a> object,
+        where all fields are optional.
+      </p>
       <dl title="dictionary TCPOptions"
-          class="idl">     
-        
+          class="idl">
+
         <dt>DOMString localAddress</dt>
-        <dd>The IPv4/6 address of the local interface, e.g. wifi or 3G, that the 
-            TCPSocket object is bound to. If the field is omitted, the <a>user agent</a> 
-            binds the socket to an IPv4/6 address based on the routing table and 
-            possibly a preselect default local interface to use for the selected 
-            <code>remoteAddress</code>. </dd>  
-        
+        <dd>The IPv4/6 address of the local interface, e.g. wifi or 3G, that the
+            TCPSocket object is bound to. If the field is omitted, the <a>user agent</a>
+            binds the socket to an IPv4/6 address based on the routing table and
+            possibly a preselect default local interface to use for the selected
+            <code>remoteAddress</code>. </dd>
+
         <dt>unsigned short localPort</dt>
-        <dd>The local port that the TCPSocket object is bound to. If the the field 
-            is omitted, the <a>user agent</a> binds the socket to an ephemeral local port 
-            decided by the system.</dd>    
-            
+        <dd>The local port that the TCPSocket object is bound to. If the the field
+            is omitted, the <a>user agent</a> binds the socket to an ephemeral local port
+            decided by the system.</dd>
+
         <dt>boolean addressReuse</dt>
-        <dd><code>true</code> allows the socket to be bound to a local 
+        <dd><code>true</code> allows the socket to be bound to a local
             address/port pair that already is in use. Default is <code>true</code>.
-            </dd>        
-            
+            </dd>
+
         <dt>boolean noDelay</dt>
-        <dd><code>true</code> if the Nagle algorithm for send coalescing, 
-            [[!NAGLE]], is disabled. Default is 
-            <code>true</code>.</dd>                
-            
+        <dd><code>true</code> if the Nagle algorithm for send coalescing,
+            [[!NAGLE]], is disabled. Default is
+            <code>true</code>.</dd>
+
         <dt>boolean useSecureTransport</dt>
-        <dd><code>true</code> if socket uses SSL or TLS. Default is 
+        <dd><code>true</code> if socket uses SSL or TLS. Default is
             <code>false</code>.</dd>
-            
+
         <dt>TCPKeepAliveOptions tcpKeepAliveOptions</dt>
-        <dd>States the "keepalive" options for the TCPSocket. TCP "keepalive" 
-            causes a packet (called a 'keepalive probe') to be sent to the remote 
-            system if a long time passes with no data or acknowledgement packets 
-            received. This packet is designed to provoke an ACK response from the 
-            peer. This enables detection of a peer which has become unreachable 
-            (e.g. powered off or disconnected from the net). If this field 
-            is omitted keepalive probes will not be sent.</dd>   
-            
+        <dd>States the "keepalive" options for the TCPSocket. TCP "keepalive"
+            causes a packet (called a 'keepalive probe') to be sent to the remote
+            system if a long time passes with no data or acknowledgement packets
+            received. This packet is designed to provoke an ACK response from the
+            peer. This enables detection of a peer which has become unreachable
+            (e.g. powered off or disconnected from the net). If this field
+            is omitted keepalive probes will not be sent.</dd>
+
         <dt>unsigned long tcpKeepAliveSparseIntvl</dt>
         <dd>The time (in seconds) between individual keepalive probes. Default
-            is 600 seconds (10 minutes).</dd>              
-                     
-        
-      </dl>       
-              
+            is 600 seconds (10 minutes).</dd>
+
+
+      </dl>
+
       <p class="issue">
-        Use of secure transport needs more investigation                 
-      </p>                     
-    </section>         
-    
-<!------------------------ Dictionary TCPServerOptions ------------------------------>   
+        Use of secure transport needs more investigation
+      </p>
+    </section>
+
+<!------------------------ Dictionary TCPServerOptions ------------------------------>
     <section>
       <h2>Dictionary <a>TCPServerOptions</a></h2>
       <p>
-        States the options for the TCPServerSocket. An instance of this dictionary 
+        States the options for the TCPServerSocket. An instance of this dictionary
         can optionally be used in the constructor of the TCPServerSocket
         object, where all fields are optional.
-      </p>      
+      </p>
       <dl title="dictionary TCPServerOptions"
           class="idl">
-          
-        <dt>DOMString localAddress</dt>
-        <dd>The IPv4/6 address of the interface, e.g. wifi or 3G, that the 
-            TCPServerSocket object is bound to. If the field is omitted, the 
-            <a>user agent</a> binds the server socket to the IPv4/6 address of the 
-            default local interface. </dd> 
-                     
-        <dt>unsigned short localPort</dt>
-        <dd>The local port that the TCPServerSocket object is bound to. If the 
-            the field is omitted, the <a>user agent</a> binds the socket to an ephemeral 
-            local port decided by the system.</dd>    
-            
-        <dt>boolean addressReuse</dt>
-        <dd><code>true</code> allows the socket to be bound to a local 
-            address/port pair that already is in use. Default is 
-            <code>true</code>.</dd>              
-        
-        <dt>boolean useSecureTransport</dt>
-        <dd><code>true</code> if socket uses SSL or TLS. Default is 
-            <code>false</code>.</dd>            
-      </dl>        
-      
-      <p class="issue">
-        Use of secure transport needs more investigation                 
-      </p>                
 
-    </section>     
-    
-<!------------------------ Dictionary UDPPermissionOptions ------------------------------>   
+        <dt>DOMString localAddress</dt>
+        <dd>The IPv4/6 address of the interface, e.g. wifi or 3G, that the
+            TCPServerSocket object is bound to. If the field is omitted, the
+            <a>user agent</a> binds the server socket to the IPv4/6 address of the
+            default local interface. </dd>
+
+        <dt>unsigned short localPort</dt>
+        <dd>The local port that the TCPServerSocket object is bound to. If the
+            the field is omitted, the <a>user agent</a> binds the socket to an ephemeral
+            local port decided by the system.</dd>
+
+        <dt>boolean addressReuse</dt>
+        <dd><code>true</code> allows the socket to be bound to a local
+            address/port pair that already is in use. Default is
+            <code>true</code>.</dd>
+
+        <dt>boolean useSecureTransport</dt>
+        <dd><code>true</code> if socket uses SSL or TLS. Default is
+            <code>false</code>.</dd>
+      </dl>
+
+      <p class="issue">
+        Use of secure transport needs more investigation
+      </p>
+
+    </section>
+
+<!------------------------ Dictionary UDPPermissionOptions ------------------------------>
     <section>
       <h2>Dictionary <a>UDPPermissionOptions</a></h2>
       <p>
-        States the options for the <a>webapp</a> to get status of permission 
-        for creating a <a>UDPSocket</a> object or to request permission to 
-        create a <a>UDPSocket</a> object. An instance of this dictionary can 
+        States the options for the <a>webapp</a> to get status of permission
+        for creating a <a>UDPSocket</a> object or to request permission to
+        create a <a>UDPSocket</a> object. An instance of this dictionary can
         optionally be used as argument to the <a>UDPPermission</a> <code>hasPermission</code>
-        and <code>requestPermission</code> methods. All fields are optional. 
-      </p>      
+        and <code>requestPermission</code> methods. All fields are optional.
+      </p>
       <dl title="dictionary UDPPermissionOptions"
-          class="idl">          
-          
+          class="idl">
+
         <dt>DOMString localAddress</dt>
-        <dd>The local interface that the <a>webapp</a> requests permission for the 
-            <a>UDPSocket</a> object to be bound to. If the field is omitted the 
-            <a>webapp</a> does not request permission to use any specific local 
-            interface, i.e. the <a>user agent</a> selects local interface.</dd>   
-        
+        <dd>The local interface that the <a>webapp</a> requests permission for the
+            <a>UDPSocket</a> object to be bound to. If the field is omitted the
+            <a>webapp</a> does not request permission to use any specific local
+            interface, i.e. the <a>user agent</a> selects local interface.</dd>
+
         <dt>unsigned short localPort</dt>
         <dd>The local port that the <a>webapp</a> requests permission for the
             <a>UDPSocket</a> object to be bound to. If the field is omitted the
             <a>webapp</a> does not request permission to use any specific local
-            port, i.e. the <a>user agent</a> selects local port.</dd>             
+            port, i.e. the <a>user agent</a> selects local port.</dd>
 
         <dt>DOMString remoteAddress</dt>
-        <dd> The host name or IPv4/6 address the <a>webapp</a> requests permission 
+        <dd> The host name or IPv4/6 address the <a>webapp</a> requests permission
              for the <a>UDPSocket</a> object to send UDP packets to. If the field
-             is omitted it means that the <a>webapp</a> requests permission 
-             for the <a>UDPSocket</a> object to send UDP packets to any peer. </dd>   
-        
+             is omitted it means that the <a>webapp</a> requests permission
+             for the <a>UDPSocket</a> object to send UDP packets to any peer. </dd>
+
         <dt>unsigned short remotePort</dt>
         <dd>The port of the peer the <a>webapp</a> requests permission for
             the <a>UDPSocket</a> object to send UDP packets to. If the field
             is omitted it means that the <a>webapp</a> requests permission for
-            the <a>UDPSocket</a> object to send UDP packets to any port. </dd>   
-   
-      </dl>   
-                  
-    </section>    
-    
-<!------------------------ Dictionary TCPPermissionOptions ------------------------------>   
+            the <a>UDPSocket</a> object to send UDP packets to any port. </dd>
+
+      </dl>
+
+    </section>
+
+<!------------------------ Dictionary TCPPermissionOptions ------------------------------>
     <section>
       <h2>Dictionary <a>TCPPermissionOptions</a></h2>
       <p>
-        States the options for the <a>webapp</a> to get status of permission 
-        for creating a <a>TCPSocket</a> object or to request permission to 
-        create a <a>TCPSocket</a> object. An instance of this dictionary can 
+        States the options for the <a>webapp</a> to get status of permission
+        for creating a <a>TCPSocket</a> object or to request permission to
+        create a <a>TCPSocket</a> object. An instance of this dictionary can
         optionally be used as argument to the <a>TCPPermission</a> <code>hasPermission</code>
-        and <code>requestPermission</code> methods. All fields are optional. 
-      </p>      
+        and <code>requestPermission</code> methods. All fields are optional.
+      </p>
       <dl title="dictionary TCPPermissionOptions"
-          class="idl">                   
+          class="idl">
 
         <dt>DOMString remoteAddress</dt>
-        <dd> The host name or IPv4/6 address the <a>webapp</a> requests permission 
+        <dd> The host name or IPv4/6 address the <a>webapp</a> requests permission
              for the <a>TCPSocket</a> object to connect to. If the field
-             is omitted it means that the <a>webapp</a> requests permission 
-             for the <a>TCPSocket</a> object to connect to any peer. </dd>   
-        
+             is omitted it means that the <a>webapp</a> requests permission
+             for the <a>TCPSocket</a> object to connect to any peer. </dd>
+
         <dt>unsigned short remotePort</dt>
         <dd>The port of the peer the <a>webapp</a> requests permission for
             the <a>TCPSocket</a> object to connect to. If the field
             is omitted it means that the <a>webapp</a> requests permission for
-            the <a>TCPSocket</a> object to connect to any port. </dd>   
-   
-      </dl>   
-                  
-    </section>     
-    
-<!------------------------ Dictionary TCPServerPermissionOptions ------------------------------>   
+            the <a>TCPSocket</a> object to connect to any port. </dd>
+
+      </dl>
+
+    </section>
+
+<!------------------------ Dictionary TCPServerPermissionOptions ------------------------------>
     <section>
       <h2>Dictionary <a>TCPServerPermissionOptions</a></h2>
       <p>
-        States the options for the <a>webapp</a> to get status of permission 
-        for creating a <a>TCPServerSocket</a> object or to request permission to 
-        create a <a>TCPServerSocket</a> object. An instance of this dictionary can 
-        optionally be used as argument to the <a>TCPServerPermission</a> 
+        States the options for the <a>webapp</a> to get status of permission
+        for creating a <a>TCPServerSocket</a> object or to request permission to
+        create a <a>TCPServerSocket</a> object. An instance of this dictionary can
+        optionally be used as argument to the <a>TCPServerPermission</a>
         <code>hasPermission</code> and <code>requestPermission</code> methods.
-        All fields are optional. 
-      </p>      
+        All fields are optional.
+      </p>
       <dl title="dictionary TCPServerPermissionOptions"
-          class="idl">          
-          
+          class="idl">
+
         <dt>DOMString localAddress</dt>
-        <dd>The local interface that the <a>webapp</a> requests permission for the 
+        <dd>The local interface that the <a>webapp</a> requests permission for the
             <a>TCPServerSocket</a> object to be bound to. If the field is omitted
-            the <a>webapp</a> does not request permission to use any specific local 
-            interface, i.e. the <a>user agent</a> selects local interface.</dd>   
-        
+            the <a>webapp</a> does not request permission to use any specific local
+            interface, i.e. the <a>user agent</a> selects local interface.</dd>
+
         <dt>unsigned short localPort</dt>
         <dd>The local port that the <a>webapp</a> requests permission for the
             <a>TCPServerSocket</a> object to be bound to. If the field is omitted
-            the <a>webapp</a> does not request permission to use any specific 
-            local port, i.e. the <a>user agent</a> selects local port.</dd>             
-   
-      </dl>   
-                  
-    </section>                    
-    
-<!------------------------ Enums ------------------------------>   
+            the <a>webapp</a> does not request permission to use any specific
+            local port, i.e. the <a>user agent</a> selects local port.</dd>
+
+      </dl>
+
+    </section>
+
+<!------------------------ Enums ------------------------------>
     <section>
       <h2> Enums </h2>
-      
+
       <section>
-        
+
         <h3>TCPUDPPermissionState</h3>
-      
+
         <dl id='enum-basic' class='idl' title='enum TCPUDPPermissionState'>
           <dt>granted</dt>
           <dd>The <a>webapp</a> has permission to use the requested interface.</dd>
           <dt>denied</dt>
-          <dd>The <a>webapp</a> has been denied permission to use the requested 
+          <dd>The <a>webapp</a> has been denied permission to use the requested
               interface.</dd>
           <dt>prompt</dt>
-          <dd>The <a>webapp</a> needs to request permission to use the 
-              requested interface by calling <code>requestPermission</code>.</dd>                  
-        </dl>          
-      </section>          
-      
-      <section>
-        
-        <h3>SocketReadyState</h3>
-      
-        <dl id='enum-basic' class='idl' title='enum SocketReadyState'>
-          <dt>opening</dt>
-          <dd>The socket is in opening state, i.e. availability of local address/port 
-              is being checked, network status is being checked, etc. For TCP a 
-              connection with a remote peer has not yet been established.</dd>
-          <dt>open</dt>
-          <dd>The socket is ready to use to send and received data. For TCP a 
-              connection with a remote peer has been established.</dd>
-          <dt>closing</dt>
-          <dd>Only used for TCP sockets. The TCP connection is going through 
-              the closing handshake, or the close() method has been invoked.</dd>
-          <dt>closed</dt>
-          <dd>The socket is closed and can not be use to send and received data. 
-              For TCP the connection has been closed or could not be opened.</dd>      
-          <dt>halfclosed</dt>
-          <dd>Only used for TCP sockets. The TCP connection has been "halfclosed"
-              by the <a>webapp</a>, which means that it is not possible to send data 
-              but it is still possible to receive.</dd>                      
-        </dl>          
-      </section>       
+          <dd>The <a>webapp</a> needs to request permission to use the
+              requested interface by calling <code>requestPermission</code>.</dd>
+        </dl>
+      </section>
 
       <section>
-        
+
+        <h3>SocketReadyState</h3>
+
+        <dl id='enum-basic' class='idl' title='enum SocketReadyState'>
+          <dt>opening</dt>
+          <dd>The socket is in opening state, i.e. availability of local address/port
+              is being checked, network status is being checked, etc. For TCP a
+              connection with a remote peer has not yet been established.</dd>
+          <dt>open</dt>
+          <dd>The socket is ready to use to send and received data. For TCP a
+              connection with a remote peer has been established.</dd>
+          <dt>closing</dt>
+          <dd>Only used for TCP sockets. The TCP connection is going through
+              the closing handshake, or the close() method has been invoked.</dd>
+          <dt>closed</dt>
+          <dd>The socket is closed and can not be use to send and received data.
+              For TCP the connection has been closed or could not be opened.</dd>
+          <dt>halfclosed</dt>
+          <dd>Only used for TCP sockets. The TCP connection has been "halfclosed"
+              by the <a>webapp</a>, which means that it is not possible to send data
+              but it is still possible to receive.</dd>
+        </dl>
+      </section>
+
+      <section>
+
         <h3>TCPKeepAliveOptions</h3>
-      
+
         <dl id='enum-basic' class='idl' title='enum TCPKeepAliveOptions'>
           <dt>off</dt>
           <dd>Don't use TCP keep-alives. This is the defult.</dd>
           <dt>frequent-then-sparse</dt>
-          <dd>Keep-alive probes every 10s for first minute, then send with 
+          <dd>Keep-alive probes every 10s for first minute, then send with
               "tcpKeepAliveSparseIntvl" after that.</dd>
           <dt>sparse</dt>
-          <dd>Keep-alive probe sent with "tcpKeepAliveSparseIntvl".</dd>                  
-        </dl>          
-      </section>           
-                  
-    </section>    
-           
-<!------------------------ Appendix ------------------------------>   
+          <dd>Keep-alive probe sent with "tcpKeepAliveSparseIntvl".</dd>
+        </dl>
+      </section>
+
+    </section>
+
+<!------------------------ Appendix ------------------------------>
     <section class='appendix'>
       <h2>Acknowledgements</h2>
       <p>
-        Many thanks to Domenic Denicola, Marcos Caceres, Jonas Sicking, Ke-Fong Lin and 
-        Alexandre Morgaut for reviewing the specification and providing very 
+        Many thanks to Domenic Denicola, Marcos Caceres, Jonas Sicking, Ke-Fong Lin and
+        Alexandre Morgaut for reviewing the specification and providing very
         valuable feedback. Also thanks to Sony colleagues Anders Edenbrandt,
-        Anders Isberg and Björn Isaksson for sharing their experience on 
+        Anders Isberg and Björn Isaksson for sharing their experience on
         socket APIs and providing support.
       </p>
     </section>


### PR DESCRIPTION
Readable stream transitioned from .ready + sync .read() to async .read() in https://github.com/whatwg/streams/pull/296. This PR updates the examples to use this new API.

It also removes a lot of trailing whitespace. The diff might be best viewed [without whitespace tracked](https://github.com/domenic/tcp-udp-sockets/commit/acc3393ca6d046dad8e7e4e35c4a58e77a8261f4?w=1).
