### PR TITLE
Update URLs and names to reflect changed name.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
           specStatus:           "ED",
 
           // the specification's short name, as in http://www.w3.org/TR/short-name/
-          shortName:            "raw-sockets",
+          shortName:            "tcp-udp-sockets",
 
           // if your specification has a subtitle that goes below the main
           // formal title, define it here
@@ -36,7 +36,7 @@
           // previousMaturity:  "WD",
 
           // if there a publicly available Editor's Draft, this is the link
-          edDraftURI:           "http://www.w3.org/2012/sysapps/raw-sockets/",
+          edDraftURI:           "http://www.w3.org/2012/sysapps/tcp-udp-sockets/",
 
           // if this is a LCWD, uncomment and set the end of its review period
           // lcEnd: "2009-08-05",
@@ -120,13 +120,13 @@
             key: "Repository",
             data: [{
                     value: "We are on Github.",
-                    href: "https://github.com/sysapps/raw-sockets"
+                    href: "https://github.com/sysapps/tcp-udp-sockets"
                 }, {
                     value: "File a bug.",
-                    href: "https://github.com/sysapps/raw-sockets/issues"
+                    href: "https://github.com/sysapps/tcp-udp-sockets/issues"
                 }, {
                     value: "Commit history.",
-                    href: "https://github.com/sysapps/raw-sockets/commits/gh-pages"
+                    href: "https://github.com/sysapps/tcp-udp-sockets/commits/gh-pages"
                 }
             ]
           }]


### PR DESCRIPTION
- According to #42.
- This is a follow-up to #61 and updates remaining URLs. Some of the currently listed URLs are broken (404), and some redirect. All new URLs are working and do not redirect.
- It seems that commit 2379ba34a6d5578befc5f9d1e8ea532d281847be accidentally reverted some changes of #61.

Please review. This is my first contribution here.
